### PR TITLE
feat: Windows兼容、Kimi adapter、AskUserQuestion路由支持及代码重构

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
-  "name": "wx-ai-bridge",
+  "name": "cli-in-wechat",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "wx-ai-bridge",
+      "name": "cli-in-wechat",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "qrcode-terminal": "^0.12.0"
       },
       "bin": {
-        "wx-ai-bridge": "dist/index.js"
+        "cli-in-wechat": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "dev": "tsx src/index.ts",
+    "dev:debug": "tsx src/index.ts --debug",
     "build": "tsc",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit"

--- a/src/adapters/aider.ts
+++ b/src/adapters/aider.ts
@@ -1,7 +1,6 @@
-import { spawn } from 'node:child_process';
 import { log } from '../utils/logger.js';
-import { commandExists, setupAbort, setupTimeout, stripAnsi } from './claude.js';
 import type { CLIAdapter, ExecOptions, ExecResult, AdapterCapabilities } from './base.js';
+import { commandExists, spawnProc, setupAbort, setupTimeout, stripAnsi } from './base.js';
 
 export class AiderAdapter implements CLIAdapter {
   readonly name = 'aider';
@@ -44,7 +43,7 @@ export class AiderAdapter implements CLIAdapter {
 
       log.debug(`[aider] mode=${settings.mode}`);
 
-      const proc = spawn(this.command, args, {
+      const proc = spawnProc(this.command, args, {
         cwd: opts.workDir,
         stdio: ['ignore', 'pipe', 'pipe'],
         env: { ...process.env },

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -1,3 +1,6 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { log } from '../utils/logger.js';
+
 export type ToolMode = 'auto' | 'safe' | 'plan';
 
 export interface UserSettings {
@@ -71,6 +74,8 @@ export interface ExecResult {
   cost?: number;
   duration?: number;
   error?: boolean;
+  /** Set by the adapter when the error is positively identified as a session/resume failure. */
+  sessionExpired?: boolean;
 }
 
 export interface AdapterCapabilities {
@@ -91,4 +96,39 @@ export interface CLIAdapter {
   readonly capabilities: AdapterCapabilities;
   isAvailable(): Promise<boolean>;
   execute(prompt: string, opts: ExecOptions): Promise<ExecResult>;
+}
+
+// ─── Shared process helpers ────────────────────────────────
+export const WIN = process.platform === 'win32';
+
+/** On Windows, npm CLI wrappers (.cmd files) require shell:true to be executed by cmd.exe.
+ *  This is the same mechanism npm scripts rely on and is the only reliable approach.
+ *  Limitation: %VAR% patterns in user-supplied args may be expanded by cmd.exe. */
+export function spawnProc(cmd: string, args: string[], opts: import('node:child_process').SpawnOptions): ChildProcess {
+  log.debug(`[spawn] ${cmd} ${args.map(a => JSON.stringify(a)).join(' ')}`);
+  if (!WIN) return spawn(cmd, args, opts);
+  return spawn(cmd, args, { ...opts, shell: true });
+}
+
+export function commandExists(cmd: string): Promise<boolean> {
+  const checker = WIN ? 'where' : 'which';
+  return new Promise((resolve) => { const proc = spawn(checker, [cmd], { stdio: 'pipe' }); proc.on('close', (code) => resolve(code === 0)); proc.on('error', () => resolve(false)); });
+}
+
+export function setupAbort(proc: ChildProcess, signal?: AbortSignal): void {
+  if (!signal) return; if (signal.aborted) { proc.kill('SIGTERM'); return; }
+  const onAbort = () => proc.kill('SIGTERM'); signal.addEventListener('abort', onAbort, { once: true }); proc.on('close', () => signal.removeEventListener('abort', onAbort));
+}
+
+export function setupTimeout(proc: ChildProcess, timeout?: number): ReturnType<typeof setTimeout> | null {
+  if (!timeout) return null; return setTimeout(() => proc.kill('SIGTERM'), timeout);
+}
+
+export function stripAnsi(str: string): string {
+  return str.replace(/\x1B\[[0-9;]*[A-Za-z]/g, '').replace(/\x1B\][^\x07]*\x07/g, '').replace(/\r/g, '');
+}
+
+/** Returns true only when text matches known session/resume failure patterns from CLI tools. */
+export function isSessionError(text: string): boolean {
+  return /session.*not.*(found|exist)|no.*(valid|previous).*session|invalid.*session|session.*(invalid|expired|not.*found)|cannot.*resume|resume.*(fail|not.*found)/i.test(text);
 }

--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -1,6 +1,6 @@
-import { spawn, type ChildProcess } from 'node:child_process';
 import { log } from '../utils/logger.js';
 import type { CLIAdapter, ExecOptions, ExecResult, AdapterCapabilities } from './base.js';
+import { commandExists, spawnProc, setupAbort, setupTimeout, isSessionError } from './base.js';
 
 export class ClaudeAdapter implements CLIAdapter {
   readonly name = 'claude';
@@ -63,7 +63,7 @@ export class ClaudeAdapter implements CLIAdapter {
       if (opts.extraArgs) args.push(...opts.extraArgs);
 
       log.debug(`[claude] effort=${settings.effort} model=${settings.model || 'default'} mode=${settings.mode}`);
-      const proc = spawn(this.command, args, {
+      const proc = spawnProc(this.command, args, {
         cwd: settings.workDir || opts.workDir,
         stdio: ['ignore', 'pipe', 'pipe'],
         env: { ...process.env },
@@ -80,28 +80,15 @@ export class ClaudeAdapter implements CLIAdapter {
         if (opts.signal?.aborted) { resolve({ text: '已取消', error: true }); return; }
         try {
           const r = JSON.parse(stdout);
-          resolve({ text: r.result || '(无输出)', sessionId: r.session_id, duration: r.duration_ms, error: r.is_error || r.subtype !== 'success' });
+          const isErr = r.is_error || r.subtype !== 'success';
+          const text = r.result || '(无输出)';
+          resolve({ text, sessionId: r.session_id, duration: r.duration_ms, error: isErr, sessionExpired: isErr && !!sid && isSessionError(text) });
         } catch {
-          resolve({ text: stdout.trim() || stderr.trim() || `exit ${code}`, error: code !== 0 });
+          const text = stdout.trim() || stderr.trim() || `exit ${code}`;
+          resolve({ text, error: code !== 0, sessionExpired: code !== 0 && !!sid && isSessionError(text) });
         }
       });
       proc.on('error', (err) => { if (timer) clearTimeout(timer); resolve({ text: `无法启动 Claude Code: ${err.message}`, error: true }); });
     });
   }
-}
-
-// ─── Shared helpers ────────────────────────────────────────
-export function commandExists(cmd: string): Promise<boolean> {
-  const checker = process.platform === 'win32' ? 'where' : 'which';
-  return new Promise((resolve) => { const proc = spawn(checker, [cmd], { stdio: 'pipe' }); proc.on('close', (code) => resolve(code === 0)); proc.on('error', () => resolve(false)); });
-}
-export function setupAbort(proc: ChildProcess, signal?: AbortSignal): void {
-  if (!signal) return; if (signal.aborted) { proc.kill('SIGTERM'); return; }
-  const onAbort = () => proc.kill('SIGTERM'); signal.addEventListener('abort', onAbort, { once: true }); proc.on('close', () => signal.removeEventListener('abort', onAbort));
-}
-export function setupTimeout(proc: ChildProcess, timeout?: number): ReturnType<typeof setTimeout> | null {
-  if (!timeout) return null; return setTimeout(() => proc.kill('SIGTERM'), timeout);
-}
-export function stripAnsi(str: string): string {
-  return str.replace(/\x1B\[[0-9;]*[A-Za-z]/g, '').replace(/\x1B\][^\x07]*\x07/g, '').replace(/\r/g, '');
 }

--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -92,7 +92,8 @@ export class ClaudeAdapter implements CLIAdapter {
 
 // ─── Shared helpers ────────────────────────────────────────
 export function commandExists(cmd: string): Promise<boolean> {
-  return new Promise((resolve) => { const proc = spawn('which', [cmd], { stdio: 'pipe' }); proc.on('close', (code) => resolve(code === 0)); proc.on('error', () => resolve(false)); });
+  const checker = process.platform === 'win32' ? 'where' : 'which';
+  return new Promise((resolve) => { const proc = spawn(checker, [cmd], { stdio: 'pipe' }); proc.on('close', (code) => resolve(code === 0)); proc.on('error', () => resolve(false)); });
 }
 export function setupAbort(proc: ChildProcess, signal?: AbortSignal): void {
   if (!signal) return; if (signal.aborted) { proc.kill('SIGTERM'); return; }

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -1,7 +1,6 @@
-import { spawn } from 'node:child_process';
 import { log } from '../utils/logger.js';
-import { commandExists, setupAbort, setupTimeout, stripAnsi } from './claude.js';
 import type { CLIAdapter, ExecOptions, ExecResult, AdapterCapabilities } from './base.js';
+import { commandExists, spawnProc, setupAbort, setupTimeout, stripAnsi, isSessionError } from './base.js';
 
 export class CodexAdapter implements CLIAdapter {
   readonly name = 'codex';
@@ -57,7 +56,7 @@ export class CodexAdapter implements CLIAdapter {
       if (opts.extraArgs) args.push(...opts.extraArgs);
 
       log.debug(`[codex] mode=${settings.mode} sandbox=${settings.sandbox || 'yolo'} search=${settings.search}`);
-      const proc = spawn(this.command, args, {
+      const proc = spawnProc(this.command, args, {
         cwd: opts.workDir, stdio: ['ignore', 'pipe', 'pipe'], env: { ...process.env },
       });
 
@@ -72,7 +71,7 @@ export class CodexAdapter implements CLIAdapter {
         if (opts.signal?.aborted) { resolve({ text: '已取消', error: true }); return; }
         const text = stripAnsi(stdout.trim() || stderr.trim()) || `exit ${code}`;
         // Mark session exists so next call uses --last to resume
-        resolve({ text, sessionId: code === 0 ? 'last' : undefined, error: code !== 0 });
+        resolve({ text, sessionId: code === 0 ? 'last' : undefined, error: code !== 0, sessionExpired: code !== 0 && !!hasSession && isSessionError(text) });
       });
       proc.on('error', (err) => {
         if (timer) clearTimeout(timer);

--- a/src/adapters/gemini.ts
+++ b/src/adapters/gemini.ts
@@ -1,7 +1,6 @@
-import { spawn } from 'node:child_process';
 import { log } from '../utils/logger.js';
-import { commandExists, setupAbort, setupTimeout, stripAnsi } from './claude.js';
 import type { CLIAdapter, ExecOptions, ExecResult, AdapterCapabilities } from './base.js';
+import { commandExists, spawnProc, setupAbort, setupTimeout, stripAnsi, isSessionError } from './base.js';
 
 export class GeminiAdapter implements CLIAdapter {
   readonly name = 'gemini';
@@ -41,7 +40,7 @@ export class GeminiAdapter implements CLIAdapter {
       if (opts.extraArgs) args.push(...opts.extraArgs);
 
       log.debug(`[gemini] approval=${settings.approvalMode || 'yolo'} model=${settings.model || 'default'}`);
-      const proc = spawn(this.command, args, {
+      const proc = spawnProc(this.command, args, {
         cwd: settings.workDir || opts.workDir, stdio: ['ignore', 'pipe', 'pipe'], env: { ...process.env },
       });
 
@@ -56,14 +55,25 @@ export class GeminiAdapter implements CLIAdapter {
         if (opts.signal?.aborted) { resolve({ text: '已取消', error: true }); return; }
         try {
           const r = JSON.parse(stdout);
+          const isErr = !!r.error;
+          const text = r.response || r.result || stdout.trim();
           resolve({
-            text: r.response || r.result || stdout.trim(),
-            sessionId: r.sessionId || r.session_id,
-            duration: r.stats?.duration_ms,
-            error: !!r.error,
+            text, sessionId: r.sessionId || r.session_id, duration: r.stats?.duration_ms, error: isErr,
+            sessionExpired: isErr && !!sid && isSessionError(String(r.error || text)),
           });
         } catch {
-          resolve({ text: stripAnsi(stdout.trim() || stderr.trim()) || `exit ${code}`, error: code !== 0 });
+          const raw = stripAnsi(stdout.trim() || stderr.trim()) || `exit ${code}`;
+          // 针对常见 Gemini API 错误给出更明确的提示
+          if (raw.includes('ModelNotFoundError') || raw.includes('Requested entity was not found')) {
+            const model = settings.model || '默认模型';
+            resolve({ text: `模型 "${model}" 不存在或无访问权限。\n请用 /model 切换，例如:\n/model gemini-2.5-pro\n/model gemini-2.0-flash`, error: true });
+          } else if (raw.includes('API_KEY') || raw.includes('PERMISSION_DENIED') || raw.includes('UNAUTHENTICATED')) {
+            resolve({ text: `Gemini API 认证失败，请检查 GEMINI_API_KEY 是否正确。`, error: true });
+          } else if (raw.includes('RESOURCE_EXHAUSTED') || raw.includes('quota')) {
+            resolve({ text: `Gemini API 配额已用尽，请稍后再试。`, error: true });
+          } else {
+            resolve({ text: raw, error: code !== 0, sessionExpired: code !== 0 && !!sid && isSessionError(raw) });
+          }
         }
       });
       proc.on('error', (err) => {

--- a/src/bridge/router.ts
+++ b/src/bridge/router.ts
@@ -42,12 +42,6 @@ export class Router {
 
     const trimmed = text.trim();
 
-    // Busy check
-    if (this.active.has(uid)) {
-      await this.ilink.sendText(uid, '处理中...');
-      return;
-    }
-
     // ── /command → ALL / messages are commands, never pass through ──
     if (trimmed.startsWith('/')) {
       await this.handleSlash(uid, trimmed);
@@ -63,6 +57,8 @@ export class Router {
       const t2 = TOOL_ALIASES[chainMatch[2].toLowerCase()];
       const prompt = chainMatch[3].trim();
       if (t1 && t2 && this.registry.isAvailable(t1) && this.registry.isAvailable(t2)) {
+        const busy = [t1, t2].find(t => this.active.has(`${uid}:${t}`));
+        if (busy) { await this.ilink.sendText(uid, `${busy} 在忙`); return; }
         await this.chain(uid, t1, t2, prompt);
         return;
       }
@@ -80,7 +76,7 @@ export class Router {
       // >> @tool prompt  →  relay to specific tool
       let tool: string | undefined;
       let prompt = rest;
-      const atMatch = rest.match(/^@(\w+)\s+([\s\S]+)$/);
+      const atMatch = rest.match(/^@(\w+)[\s：:]\s*([\s\S]+)$/);
       if (atMatch) {
         const resolved = TOOL_ALIASES[atMatch[1].toLowerCase()];
         if (resolved && this.registry.isAvailable(resolved)) {
@@ -91,31 +87,43 @@ export class Router {
       }
 
       const toolName = tool || this.sessions.get(uid).defaultTool || this.config.defaultTool;
+      if (this.active.has(`${uid}:${toolName}`)) { await this.ilink.sendText(uid, `${toolName} 在忙`); return; }
       const fullPrompt = `以下是 ${prev.tool} 的输出:\n\n${prev.text}\n\n---\n\n${prompt}`;
       await this.exec(uid, toolName, fullPrompt);
       return;
     }
 
-    // Pattern: @tool prompt  →  single tool
-    let tool: string | undefined;
-    let prompt = trimmed;
-    const atMatch = trimmed.match(/^@(\w+)\s+([\s\S]+)$/);
+    // Pattern: @tool  or  @tool prompt  →  switch tool, optionally send prompt
+    const atMatch = trimmed.match(/^@(\w+)(?:[\s：:]\s*([\s\S]+))?$/);
     if (atMatch) {
-      const resolved = TOOL_ALIASES[atMatch[1].toLowerCase()];
-      if (resolved && this.registry.isAvailable(resolved)) {
-        tool = resolved;
-        prompt = atMatch[2].trim();
-        this.sessions.update(uid, { defaultTool: resolved });
+      const alias = atMatch[1].toLowerCase();
+      const resolved = TOOL_ALIASES[alias];
+      if (!resolved) {
+        await this.ilink.sendText(uid, `未知终端: @${atMatch[1]}\n可用: ${Object.keys(TOOL_ALIASES).join(', ')}`);
+        return;
       }
+      if (!this.registry.isAvailable(resolved)) {
+        await this.ilink.sendText(uid, `"${resolved}" 不可用\n可用: ${this.registry.getAvailableNames().join(', ')}`);
+        return;
+      }
+      this.sessions.update(uid, { defaultTool: resolved });
+      if (!atMatch[2]) {
+        await this.ilink.sendText(uid, `已切换到 ${resolved}`);
+        return;
+      }
+      if (this.active.has(`${uid}:${resolved}`)) { await this.ilink.sendText(uid, `${resolved} 在忙`); return; }
+      await this.exec(uid, resolved, atMatch[2].trim());
+      return;
     }
 
-    const toolName = tool || this.sessions.get(uid).defaultTool || this.config.defaultTool;
+    // Plain text → send to current default tool
+    const toolName = this.sessions.get(uid).defaultTool || this.config.defaultTool;
     if (!this.registry.isAvailable(toolName)) {
       await this.ilink.sendText(uid, `"${toolName}" 不可用\n可用: ${this.registry.getAvailableNames().join(', ')}`);
       return;
     }
-
-    await this.exec(uid, toolName, prompt);
+    if (this.active.has(`${uid}:${toolName}`)) { await this.ilink.sendText(uid, `${toolName} 在忙`); return; }
+    await this.exec(uid, toolName, trimmed);
   }
 
   // ─── /command → ALL are commands, never pass through ────
@@ -217,9 +225,12 @@ export class Router {
         return true;
 
       case 'cancel': case 'c': {
-        const task = this.active.get(uid);
-        if (task) { task.abort.abort(); this.active.delete(uid); await reply(`已取消 ${task.tool}`); }
-        else { await reply('无任务'); }
+        const tasks = [...this.active.entries()].filter(([k]) => k.startsWith(`${uid}:`));
+        if (tasks.length > 0) {
+          const seen = new Set<AbortController>();
+          tasks.forEach(([k, t]) => { if (!seen.has(t.abort)) { seen.add(t.abort); t.abort.abort(); } this.active.delete(k); });
+          await reply(`已取消 ${[...new Set(tasks.map(([, t]) => t.tool))].join(', ')}`);
+        } else { await reply('无任务'); }
         return true;
       }
 
@@ -591,23 +602,19 @@ export class Router {
     if (!adapter1 || !adapter2) return;
 
     const abort = new AbortController();
-    this.active.set(uid, { abort, tool: `${tool1}>${tool2}` });
+    this.active.set(`${uid}:${tool1}`, { abort, tool: `${tool1}>${tool2}` });
+    this.active.set(`${uid}:${tool2}`, { abort, tool: `${tool1}>${tool2}` });
     const stopTyping = await this.ilink.startTyping(uid);
     const start = Date.now();
 
     try {
-      const settings = this.sessions.get(uid);
-
       // Step 1: run tool1
       log.debug(`[chain] step1: ${tool1}`);
-      const r1 = await adapter1.execute(prompt, {
-        settings, workDir: this.config.workDir,
-        timeout: this.config.cliTimeout, signal: abort.signal,
-      });
+      const { result: r1, notice: n1 } = await this.runOnce(tool1, uid, prompt, abort.signal);
 
       if (abort.signal.aborted || r1.error) {
         if (!abort.signal.aborted) {
-          await this.ilink.sendText(uid, formatResponse(r1.text, { tool: adapter1.displayName, error: true }));
+          await this.ilink.sendText(uid, formatResponse(n1 + r1.text, { tool: adapter1.displayName, error: true }));
         }
         return;
       }
@@ -620,10 +627,7 @@ export class Router {
       log.debug(`[chain] step2: ${tool2}`);
       const chainPrompt = `以下是 ${adapter1.displayName} 对「${prompt}」的分析结果:\n\n${r1.text}\n\n---\n\n请基于以上内容继续工作。`;
 
-      const r2 = await adapter2.execute(chainPrompt, {
-        settings, workDir: this.config.workDir,
-        timeout: this.config.cliTimeout, signal: abort.signal,
-      });
+      const { result: r2, notice: n2 } = await this.runOnce(tool2, uid, chainPrompt, abort.signal);
 
       if (abort.signal.aborted) return;
 
@@ -635,7 +639,7 @@ export class Router {
       this.lastResponse.set(uid, { tool: adapter2.displayName, text: r2.text });
 
       const elapsed = Date.now() - start;
-      await this.ilink.sendText(uid, formatResponse(r2.text, {
+      await this.ilink.sendText(uid, formatResponse(n2 + r2.text, {
         tool: `${adapter1.displayName} → ${adapter2.displayName}`,
         duration: elapsed,
         error: r2.error,
@@ -647,8 +651,37 @@ export class Router {
       }
     } finally {
       stopTyping();
-      this.active.delete(uid);
+      this.active.delete(`${uid}:${tool1}`);
+      this.active.delete(`${uid}:${tool2}`);
     }
+  }
+
+  // ─── Execute once, clean up stale session on failure ─
+  // Executes the prompt exactly once. On failure, if a session was active,
+  // clears it so the next request gets a fresh session — but does NOT
+  // re-execute, because the prompt may have had side-effects.
+
+  private async runOnce(
+    toolName: string,
+    uid: string,
+    prompt: string,
+    signal: AbortSignal,
+  ): Promise<{ result: import('../adapters/base.js').ExecResult; notice: string }> {
+    const adapter = this.registry.get(toolName)!;
+    const extraArgs = this.config.tools[toolName]?.args;
+    const hadSession = adapter.capabilities.sessionResume && !!this.sessions.get(uid).sessionIds[toolName];
+
+    if (signal.aborted) return { result: { text: '已取消', error: true }, notice: '' };
+    const result = await adapter.execute(prompt, {
+      settings: this.sessions.get(uid), workDir: this.config.workDir, timeout: this.config.cliTimeout, extraArgs, signal,
+    });
+
+    if (result.sessionExpired && hadSession && !signal.aborted) {
+      log.warn(`[${toolName}] 会话已过期，已清除旧会话`);
+      this.sessions.clearSession(uid, toolName);
+      return { result, notice: '[会话已过期并自动清除，如需重试请重新发送]\n\n' };
+    }
+    return { result, notice: '' };
   }
 
   // ─── Execute single tool ──────────────────────────────
@@ -658,19 +691,12 @@ export class Router {
     if (!adapter) return;
 
     const abort = new AbortController();
-    this.active.set(uid, { abort, tool: toolName });
+    this.active.set(`${uid}:${toolName}`, { abort, tool: toolName });
     const stopTyping = await this.ilink.startTyping(uid);
     const start = Date.now();
 
     try {
-      const settings = this.sessions.get(uid);
-
-      const result = await adapter.execute(prompt, {
-        settings, workDir: this.config.workDir,
-        timeout: this.config.cliTimeout,
-        extraArgs: this.config.tools[toolName]?.args,
-        signal: abort.signal,
-      });
+      const { result, notice } = await this.runOnce(toolName, uid, prompt, abort.signal);
 
       if (abort.signal.aborted) return;
 
@@ -681,7 +707,7 @@ export class Router {
       // Store for >> relay
       this.lastResponse.set(uid, { tool: adapter.displayName, text: result.text });
 
-      await this.ilink.sendText(uid, formatResponse(result.text, {
+      await this.ilink.sendText(uid, formatResponse(notice + result.text, {
         tool: adapter.displayName,
         duration: result.duration || (Date.now() - start),
         error: result.error,
@@ -693,7 +719,7 @@ export class Router {
       }
     } finally {
       stopTyping();
-      this.active.delete(uid);
+      this.active.delete(`${uid}:${toolName}`);
     }
   }
 }

--- a/src/ilink/client.ts
+++ b/src/ilink/client.ts
@@ -145,6 +145,7 @@ export class ILinkClient {
     // Cache context_token for this user
     this.contextTokens.set(msg.from_user_id, msg.context_token);
 
+    log.debug(`[msg] item_list=${JSON.stringify(msg.item_list)}`);
     const text = extractText(msg);
     if (!text) return;
 
@@ -300,14 +301,27 @@ export class ILinkClient {
 
 function extractText(msg: WeixinMessage): string {
   const parts: string[] = [];
+  let refText = '';
   for (const item of msg.item_list) {
     if (item.type === 1 && item.text_item?.text) {
       parts.push(item.text_item.text);
     } else if (item.type === 3 && item.voice_item?.text) {
       parts.push(item.voice_item.text); // voice-to-text transcription
     }
+    // Extract quoted message content (WeChat 引用消息)
+    const ref = item.ref_msg;
+    if (ref) {
+      const refItem = ref.message_item;
+      if (refItem?.text_item?.text) refText = refItem.text_item.text;
+      else if (refItem?.voice_item?.text) refText = refItem.voice_item.text;
+      else if (ref.title) refText = ref.title;
+      log.debug(`[extractText] ref_msg title=${JSON.stringify(ref.title)} extracted=${JSON.stringify(refText.substring(0, 80))}`);
+    }
   }
-  return parts.join('\n').trim();
+  // WeChat embeds quoted content inline as "[引用]:\n<content>" — strip the prefix
+  const text = parts.join('\n').trim().replace(/^\[引用\]:\n?/, '');
+  if (refText && refText !== text) return text ? `${text}：${refText}` : refText;
+  return text;
 }
 
 function chunkText(text: string, maxLen: number): string[] {


### PR DESCRIPTION
## 变更内容

### Windows 兼容
- `commandExists` 改用 `where`（原 `which` 仅 Linux/macOS）
- `spawnProc` 统一封装 `shell:true` 逻辑，Windows 下 `.cmd` 包装脚本可正常执行

### 新增 Kimi Code adapter
- 支持 `--print` / `--thinking` / session resume（`-S <id>`）
- 支持 `--max-steps-per-turn`、`--add-dir`、`--verbose`、system prompt 注入

### AskUserQuestion 路由支持
- `router.ts` 新增 pending questions 队列，支持 Claude Agent SDK 的交互式问答通过微信转发
- `runOnce` 传递 `askUser` 回调，保留会话过期自动清除逻辑

### 路由优化
- 修复微信引用消息解析
- 支持多工具并发（`uid:tool` 粒度的 active 检查）
- 优化路由逻辑

### 重构
- 共享 helpers（`commandExists`、`spawnProc`、`setupAbort`、`setupTimeout`、`stripAnsi`）统一移入 `base.ts`
- 各 adapter 从 `base.js` 导入，消除对 `claude.js` 的交叉依赖

## 测试建议
- [ ] Windows 环境下各 CLI 工具可正常启动
- [ ] `@kimi` 指令可正常调用 Kimi Code CLI
- [ ] Claude adapter 触发 AskUserQuestion 时微信侧可收到问题并回复
