### PR TITLE
feat: add file transfer between WeChat and CLI tools

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,227 @@
+# 文件传输功能实现
+
+> 本次修改为 cli-in-wechat 添加了完整的文件传输功能，支持在微信和 CLI 工具之间收发文件。
+
+## 功能概述
+
+| 功能 | 说明 |
+|------|------|
+| 接收文件 | 微信发送的图片/文件/视频自动下载并传给 CLI 处理 |
+| 发送文件 | `/send <路径>` 命令发送本地文件到微信 |
+
+## 新增文件
+
+### `src/utils/media.ts`
+
+媒体文件下载工具，核心功能：
+
+```typescript
+// 下载媒体文件
+downloadMedia(media: CDNMedia, options): Promise<DownloadedMedia>
+
+// 下载图片/文件/视频
+downloadImage(item: ImageItem, workDir?): Promise<DownloadedMedia>
+downloadFile(item: FileItem, workDir?): Promise<DownloadedMedia>
+downloadVideo(item: VideoItem, workDir?): Promise<DownloadedMedia>
+
+// 复制文件到工作目录
+copyMediaToWorkDir(media: DownloadedMedia, workDir: string): DownloadedMedia
+```
+
+**关键实现细节：**
+
+1. **下载地址**：优先使用 `media.full_url`（微信 CDN 地址），否则用 `encrypt_query_param` 构建
+2. **文件解密**：微信 CDN 文件是加密的，需要 AES-128-ECB 解密
+3. **工作目录**：文件会复制到 `<workDir>/.wx-media/` 子目录，便于 CLI 工具访问
+
+```
+用户工作目录/
+└── .wx-media/
+    ├── document.pdf
+    ├── image.jpg
+    └── video.mp4
+```
+
+## 修改的文件
+
+### `src/ilink/types.ts`
+
+添加 `full_url` 字段：
+
+```typescript
+export interface CDNMedia {
+  encrypt_query_param: string;
+  aes_key: string;
+  encrypt_type?: number;
+  full_url?: string;  // 新增：微信 CDN 下载地址
+}
+```
+
+### `src/ilink/client.ts`
+
+**新增方法：**
+
+```typescript
+// 发送文件到微信
+async sendFile(userId: string, filePath: string, title?: string): Promise<void>
+async sendImage(userId: string, imagePath: string, caption?: string): Promise<void>
+async sendVideo(userId: string, videoPath: string): Promise<void>
+
+// 上传文件到 CDN
+private async uploadToCdn(userId: string, filePath: string, mediaType: number)
+```
+
+**文件发送流程：**
+
+```
+1. 读取本地文件 → 计算 MD5
+2. 生成随机 AES 密钥
+3. 调用 ilink/bot/getuploadurl 获取上传参数
+4. AES-128-ECB 加密后上传到 novac2c.cdn.weixin.qq.com
+5. 获取 downloadParam
+6. 调用 ilink/bot/sendmessage 发送文件消息
+```
+
+**修改 `parseMessage`：**
+
+- 新增对 `type=2`（图片）、`type=4`（文件）、`type=5`（视频）的处理
+- 自动下载并返回 `DownloadedMedia[]`
+
+### `src/bridge/router.ts`
+
+1. **新增 `/send` 命令**（行 560-585）：
+   ```
+   /send <文件路径>  发送文件到微信
+   ```
+   自动识别文件类型（图片/视频/普通文件）
+
+2. **修改 `handle` 方法**：处理 `DownloadedMedia[]` 并传递给 CLI
+
+3. **新增 `mediaContext` 构建**：将文件信息注入到 prompt
+
+### `src/adapters/*.ts`（所有适配器）
+
+**新增 `buildMediaPrompt` 函数：**
+
+```typescript
+function buildMediaPrompt(prompt: string, media?: DownloadedMedia[], workDir?: string): string
+```
+
+生成的提示词格式：
+
+```
+已接收到用户通过微信发送的文件：
+
+- 文件名.pdf
+  类型: 文件
+  大小: 123.4KB
+  路径: .wx-media/文件名.pdf
+
+文件已保存到工作目录，等待您的指令。
+```
+
+### `src/utils/crypto.ts`
+
+新增函数：
+
+```typescript
+// 编码 AES 密钥（hex -> base64）
+export function encodeMessageAesKey(aeskey: Buffer): string
+
+// 计算 MD5
+export function md5(data: Buffer | string): string
+```
+
+## 关键 Bug 修复
+
+### 1. Windows shell 换行符问题
+
+**问题**：`shell: true` 在 Windows 上会把 `\n` 当作字面字符，导致 CLI 收到错误的 prompt。
+
+**解决**：改用 stdin 传递提示词。
+
+```typescript
+// 之前（错误）
+const args = ['-p', prompt, ...];
+
+// 之后（正确）
+const args = [...];
+proc.stdin!.write(prompt, 'utf8');
+proc.stdin!.end();
+```
+
+**影响文件**：`src/adapters/claude.ts`
+
+### 2. 文件解密失败
+
+**问题**：下载的文件无法读取，文件头是乱码。
+
+**原因**：微信 CDN 文件是 AES 加密的，需要解密。
+
+**解决**：尝试 ECB 和 CBC 两种解密方式，检查解密结果是否为有效文件头。
+
+```typescript
+function decryptMedia(data: Buffer, aesKeyBase64: string): Buffer {
+  // 先尝试 ECB（微信上传用的是 ECB）
+  // 检查文件头是否有效（%PDF, PK, PNG 等）
+  // 失败则尝试 CBC
+}
+```
+
+### 3. 文件路径问题
+
+**问题**：文件下载到 `~/.wx-ai-bridge/media/`，但 CLI 工具的工作目录是项目目录，找不到文件。
+
+**解决**：在 `buildMediaPrompt` 中调用 `copyMediaToWorkDir` 复制到工作目录的 `.wx-media/` 子目录。
+
+## 使用方式
+
+### 接收文件
+
+在微信中发送文件，CLI 工具会自动接收：
+
+```
+微信发送: document.pdf
+CLI 收到提示:
+已接收到用户通过微信发送的文件：
+- document.pdf
+  类型: 文件
+  大小: 45.2KB
+  路径: .wx-media/document.pdf
+文件已保存到工作目录，等待您的指令。
+```
+
+### 发送文件
+
+在微信中发送命令：
+
+```
+/send C:\Users\xxx\document.pdf    发送文件
+/send C:\Users\xxx\photo.jpg       发送图片（自动识别）
+/send C:\Users\xxx\video.mp4       发送视频（自动识别）
+```
+
+## 依赖说明
+
+- **iLink API 端点**：
+  - `ilink/bot/getuploadurl` - 获取上传参数
+  - `ilink/bot/sendmessage` - 发送消息
+- **微信 CDN**：
+  - 上传：`https://novac2c.cdn.weixin.qq.com/c2c/upload`
+  - 下载：`full_url` 字段
+
+## 注意事项
+
+1. **文件大小限制**：图片 20MB、文件 50MB、视频 100MB
+2. **工作目录**：确保 `/dir` 设置正确，文件会保存到 `<workDir>/.wx-media/`
+3. **解密**：所有从微信 CDN 下载的文件都需要 AES 解密
+4. **清理**：`.wx-media/` 目录不会自动清理，需要手动删除
+
+## 待测试
+
+- **发送文件到微信**：`/send` 命令的上传功能尚未完整测试
+- 需要验证：
+  - `ilink/bot/getuploadurl` API 调用是否正确
+  - AES-128-ECB 加密上传是否成功
+  - 微信端能否正常接收文件
+- 如有问题，可参考 https://github.com/UNLINEARITY/CLI-WeChat-Bridge 的实现

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "qrcode-terminal": "^0.12.0"
       },
       "bin": {
-        "cli-in-wechat": "dist/index.js"
+        "cli-in-wechat": "dist/index.js",
+        "wcli": "dist/index.js"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcess } from 'node:child_process';
 import { log } from '../utils/logger.js';
+import type { DownloadedMedia } from '../utils/media.js';
 
 export type ToolMode = 'auto' | 'safe' | 'plan';
 
@@ -83,6 +84,7 @@ export interface ExecOptions {
   extraArgs?: string[];
   signal?: AbortSignal;
   askUser?: (req: AskUserRequest) => Promise<Record<string, string>>;
+  media?: DownloadedMedia[];
 }
 
 export interface ExecResult {

--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -1,6 +1,34 @@
 import { log } from '../utils/logger.js';
 import type { CLIAdapter, ExecOptions, ExecResult, AdapterCapabilities } from './base.js';
 import { commandExists, spawnProc, setupAbort, setupTimeout, isSessionError } from './base.js';
+import type { DownloadedMedia } from '../utils/media.js';
+import { copyMediaToWorkDir } from '../utils/media.js';
+
+function buildMediaPrompt(prompt: string, media?: DownloadedMedia[], workDir?: string): string {
+  if (!media || media.length === 0) return prompt;
+  
+  // 复制文件到工作目录
+  const copiedMedia = workDir ? media.map(m => copyMediaToWorkDir(m, workDir)) : media;
+  
+  const fileList = copiedMedia.map(m => {
+    const relativePath = workDir && m.path.startsWith(workDir) 
+      ? m.path.slice(workDir.length).replace(/^[\/\\]/, '')
+      : m.path;
+    const typeNames: Record<string, string> = { image: '图片', file: '文件', video: '视频' };
+    const sizeStr = m.size ? `${(m.size / 1024).toFixed(1)}KB` : '未知大小';
+    return `- ${m.fileName}\n  类型: ${typeNames[m.type] || '文件'}\n  大小: ${sizeStr}\n  路径: ${relativePath}`;
+  }).join('\n\n');
+  
+  const userPrompt = prompt.trim() && !prompt.startsWith('[文件:') && !prompt.startsWith('[图片:') && !prompt.startsWith('[视频:')
+    ? `\n\n用户说：${prompt}`
+    : '';
+  
+  return `已接收到用户通过微信发送的文件：
+
+${fileList}
+
+文件已保存到工作目录，等待您的指令。${userPrompt}`;
+}
 
 export class ClaudeAdapter implements CLIAdapter {
   readonly name = 'claude';
@@ -15,13 +43,20 @@ export class ClaudeAdapter implements CLIAdapter {
 
   async execute(prompt: string, opts: ExecOptions): Promise<ExecResult> {
     const { settings } = opts;
+    const workDir = settings.workDir || opts.workDir;
+    const fullPrompt = buildMediaPrompt(prompt, opts.media, workDir);
+    
+    log.debug(`[claude] workDir: ${workDir}`);
+    if (opts.media && opts.media.length > 0) {
+      log.debug(`[claude] media paths: ${opts.media.map(m => m.path).join(', ')}`);
+    }
 
     // Try Agent SDK for full interactive support (AskUserQuestion)
     try {
-      return await this.executeWithSDK(prompt, opts);
+      return await this.executeWithSDK(fullPrompt, opts);
     } catch (sdkErr) {
       log.warn(`[claude] Agent SDK failed, falling back to CLI: ${(sdkErr as Error).message}`);
-      return this.executeWithCLI(prompt, opts);
+      return this.executeWithCLI(fullPrompt, opts);
     }
   }
 
@@ -131,8 +166,9 @@ export class ClaudeAdapter implements CLIAdapter {
   private executeWithCLI(prompt: string, opts: ExecOptions): Promise<ExecResult> {
     return new Promise((resolve) => {
       const { settings } = opts;
-      // --verbose is required by Claude CLI when using stream-json in -p mode.
-      const args = ['-p', prompt, '--output-format', 'stream-json', '--verbose'];
+      // Prompt is passed via stdin below to avoid Windows cmd.exe issues with
+      // special characters. --verbose is required for stream-json in -p mode.
+      const args = ['-p', '--output-format', 'stream-json', '--verbose'];
       if (settings.showThoughts) args.push('--thinking', 'enabled');
 
       switch (settings.mode) {
@@ -154,11 +190,17 @@ export class ClaudeAdapter implements CLIAdapter {
       if (opts.extraArgs) args.push(...opts.extraArgs);
 
       log.debug(`[claude] effort=${settings.effort} model=${settings.model || 'default'} mode=${settings.mode}`);
+      log.debug(`[claude] stdin prompt length: ${prompt.length}`);
+      
       const proc = spawnProc(this.command, args, {
         cwd: settings.workDir || opts.workDir,
-        stdio: ['ignore', 'pipe', 'pipe'],
+        stdio: ['pipe', 'pipe', 'pipe'],
         env: { ...process.env },
       });
+
+      // 通过 stdin 传递提示词
+      proc.stdin!.write(prompt, 'utf8');
+      proc.stdin!.end();
 
       setupAbort(proc, opts.signal);
       const timer = setupTimeout(proc, opts.timeout);

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -1,6 +1,33 @@
 import { log } from '../utils/logger.js';
 import type { CLIAdapter, ExecOptions, ExecResult, AdapterCapabilities } from './base.js';
 import { commandExists, spawnProc, setupAbort, setupTimeout, stripAnsi, isSessionError } from './base.js';
+import type { DownloadedMedia } from '../utils/media.js';
+import { copyMediaToWorkDir } from '../utils/media.js';
+
+function buildMediaPrompt(prompt: string, media?: DownloadedMedia[], workDir?: string): string {
+  if (!media || media.length === 0) return prompt;
+  
+  const copiedMedia = workDir ? media.map(m => copyMediaToWorkDir(m, workDir)) : media;
+  
+  const fileList = copiedMedia.map(m => {
+    const relativePath = workDir && m.path.startsWith(workDir) 
+      ? m.path.slice(workDir.length).replace(/^[\/\\]/, '')
+      : m.path;
+    const typeNames: Record<string, string> = { image: '图片', file: '文件', video: '视频' };
+    const sizeStr = m.size ? `${(m.size / 1024).toFixed(1)}KB` : '未知大小';
+    return `- ${m.fileName}\n  类型: ${typeNames[m.type] || '文件'}\n  大小: ${sizeStr}\n  路径: ${relativePath}`;
+  }).join('\n\n');
+  
+  const userPrompt = prompt.trim() && !prompt.startsWith('[文件:') && !prompt.startsWith('[图片:') && !prompt.startsWith('[视频:')
+    ? `\n\n用户说：${prompt}`
+    : '';
+  
+  return `已接收到用户通过微信发送的文件：
+
+${fileList}
+
+文件已保存到工作目录，等待您的指令。${userPrompt}`;
+}
 
 export class CodexAdapter implements CLIAdapter {
   readonly name = 'codex';
@@ -16,6 +43,8 @@ export class CodexAdapter implements CLIAdapter {
   execute(prompt: string, opts: ExecOptions): Promise<ExecResult> {
     return new Promise((resolve) => {
       const { settings } = opts;
+      const workDir = settings.workDir || opts.workDir;
+      const fullPrompt = buildMediaPrompt(prompt, opts.media, workDir);
       const args: string[] = [];
       const hasSession = settings.sessionIds[this.name];
 
@@ -59,8 +88,8 @@ export class CodexAdapter implements CLIAdapter {
       });
 
       // Pass prompt via stdin to avoid Windows cmd.exe Unicode encoding issues
-      log.debug(`[codex] stdin: ${prompt.substring(0, 200)}${prompt.length > 200 ? '…' : ''}`);
-      proc.stdin!.write(prompt, 'utf8');
+      log.debug(`[codex] stdin: ${fullPrompt.substring(0, 200)}${fullPrompt.length > 200 ? '…' : ''}`);
+      proc.stdin!.write(fullPrompt, 'utf8');
       proc.stdin!.end();
 
       setupAbort(proc, opts.signal);

--- a/src/adapters/gemini.ts
+++ b/src/adapters/gemini.ts
@@ -1,6 +1,33 @@
 import { log } from '../utils/logger.js';
 import type { CLIAdapter, ExecOptions, ExecResult, AdapterCapabilities } from './base.js';
 import { commandExists, spawnProc, setupAbort, setupTimeout, stripAnsi, isSessionError } from './base.js';
+import type { DownloadedMedia } from '../utils/media.js';
+import { copyMediaToWorkDir } from '../utils/media.js';
+
+function buildMediaPrompt(prompt: string, media?: DownloadedMedia[], workDir?: string): string {
+  if (!media || media.length === 0) return prompt;
+  
+  const copiedMedia = workDir ? media.map(m => copyMediaToWorkDir(m, workDir)) : media;
+  
+  const fileList = copiedMedia.map(m => {
+    const relativePath = workDir && m.path.startsWith(workDir) 
+      ? m.path.slice(workDir.length).replace(/^[\/\\]/, '')
+      : m.path;
+    const typeNames: Record<string, string> = { image: '图片', file: '文件', video: '视频' };
+    const sizeStr = m.size ? `${(m.size / 1024).toFixed(1)}KB` : '未知大小';
+    return `- ${m.fileName}\n  类型: ${typeNames[m.type] || '文件'}\n  大小: ${sizeStr}\n  路径: ${relativePath}`;
+  }).join('\n\n');
+  
+  const userPrompt = prompt.trim() && !prompt.startsWith('[文件:') && !prompt.startsWith('[图片:') && !prompt.startsWith('[视频:')
+    ? `\n\n用户说：${prompt}`
+    : '';
+  
+  return `已接收到用户通过微信发送的文件：
+
+${fileList}
+
+文件已保存到工作目录，等待您的指令。${userPrompt}`;
+}
 
 export class GeminiAdapter implements CLIAdapter {
   readonly name = 'gemini';
@@ -16,6 +43,8 @@ export class GeminiAdapter implements CLIAdapter {
   execute(prompt: string, opts: ExecOptions): Promise<ExecResult> {
     return new Promise((resolve) => {
       const { settings } = opts;
+      const workDir = settings.workDir || opts.workDir;
+      const fullPrompt = buildMediaPrompt(prompt, opts.media, workDir);
       // Pass prompt via stdin to avoid Windows cmd.exe special-character issues
       // (e.g. "|" in quoted messages being interpreted as a pipe by cmd.exe with shell:true).
       // Non-TTY stdin + --output-format json triggers headless mode without needing -p.
@@ -48,8 +77,8 @@ export class GeminiAdapter implements CLIAdapter {
       });
 
       // Write prompt to stdin
-      log.debug(`[gemini] stdin: ${prompt.substring(0, 200)}${prompt.length > 200 ? '…' : ''}`);
-      proc.stdin!.write(prompt, 'utf8');
+      log.debug(`[gemini] stdin: ${fullPrompt.substring(0, 200)}${fullPrompt.length > 200 ? '…' : ''}`);
+      proc.stdin!.write(fullPrompt, 'utf8');
       proc.stdin!.end();
 
       setupAbort(proc, opts.signal);

--- a/src/adapters/kimi.ts
+++ b/src/adapters/kimi.ts
@@ -1,6 +1,33 @@
 import { log } from '../utils/logger.js';
 import type { CLIAdapter, ExecOptions, ExecResult, AdapterCapabilities } from './base.js';
 import { commandExists, spawnProc, setupAbort, setupTimeout, stripAnsi } from './base.js';
+import type { DownloadedMedia } from '../utils/media.js';
+import { copyMediaToWorkDir } from '../utils/media.js';
+
+function buildMediaPrompt(prompt: string, media?: DownloadedMedia[], workDir?: string): string {
+  if (!media || media.length === 0) return prompt;
+  
+  const copiedMedia = workDir ? media.map(m => copyMediaToWorkDir(m, workDir)) : media;
+  
+  const fileList = copiedMedia.map(m => {
+    const relativePath = workDir && m.path.startsWith(workDir) 
+      ? m.path.slice(workDir.length).replace(/^[\/\\]/, '')
+      : m.path;
+    const typeNames: Record<string, string> = { image: '图片', file: '文件', video: '视频' };
+    const sizeStr = m.size ? `${(m.size / 1024).toFixed(1)}KB` : '未知大小';
+    return `- ${m.fileName}\n  类型: ${typeNames[m.type] || '文件'}\n  大小: ${sizeStr}\n  路径: ${relativePath}`;
+  }).join('\n\n');
+  
+  const userPrompt = prompt.trim() && !prompt.startsWith('[文件:') && !prompt.startsWith('[图片:') && !prompt.startsWith('[视频:')
+    ? `\n\n用户说：${prompt}`
+    : '';
+  
+  return `已接收到用户通过微信发送的文件：
+
+${fileList}
+
+文件已保存到工作目录，等待您的指令。${userPrompt}`;
+}
 
 export class KimiAdapter implements CLIAdapter {
   readonly name = 'kimi';
@@ -16,10 +43,12 @@ export class KimiAdapter implements CLIAdapter {
   execute(prompt: string, opts: ExecOptions): Promise<ExecResult> {
     return new Promise((resolve) => {
       const { settings } = opts;
+      const workDir = settings.workDir || opts.workDir;
+      const fullPrompt = buildMediaPrompt(prompt, opts.media, workDir);
       const args: string[] = [];
 
       // ── Prompt ──
-      args.push('-p', prompt);
+      args.push('-p', fullPrompt);
 
       // ── Print mode (non-interactive, implies --yolo) ──
       args.push('--print');

--- a/src/adapters/opencode.ts
+++ b/src/adapters/opencode.ts
@@ -1,6 +1,33 @@
 import { log } from '../utils/logger.js';
 import type { CLIAdapter, ExecOptions, ExecResult, AdapterCapabilities } from './base.js';
 import { commandExists, spawnProc, setupAbort, setupTimeout, stripAnsi } from './base.js';
+import type { DownloadedMedia } from '../utils/media.js';
+import { copyMediaToWorkDir } from '../utils/media.js';
+
+function buildMediaPrompt(prompt: string, media?: DownloadedMedia[], workDir?: string): string {
+  if (!media || media.length === 0) return prompt;
+  
+  const copiedMedia = workDir ? media.map(m => copyMediaToWorkDir(m, workDir)) : media;
+  
+  const fileList = copiedMedia.map(m => {
+    const relativePath = workDir && m.path.startsWith(workDir) 
+      ? m.path.slice(workDir.length).replace(/^[\/\\]/, '')
+      : m.path;
+    const typeNames: Record<string, string> = { image: '图片', file: '文件', video: '视频' };
+    const sizeStr = m.size ? `${(m.size / 1024).toFixed(1)}KB` : '未知大小';
+    return `- ${m.fileName}\n  类型: ${typeNames[m.type] || '文件'}\n  大小: ${sizeStr}\n  路径: ${relativePath}`;
+  }).join('\n\n');
+  
+  const userPrompt = prompt.trim() && !prompt.startsWith('[文件:') && !prompt.startsWith('[图片:') && !prompt.startsWith('[视频:')
+    ? `\n\n用户说：${prompt}`
+    : '';
+  
+  return `已接收到用户通过微信发送的文件：
+
+${fileList}
+
+文件已保存到工作目录，等待您的指令。${userPrompt}`;
+}
 
 export class OpenCodeAdapter implements CLIAdapter {
   readonly name = 'opencode';
@@ -16,7 +43,12 @@ export class OpenCodeAdapter implements CLIAdapter {
   execute(prompt: string, opts: ExecOptions): Promise<ExecResult> {
     return new Promise((resolve) => {
       const { settings } = opts;
-      const args = ['run', prompt, '--format', 'json'];
+      const workDir = settings.workDir || opts.workDir;
+      const fullPrompt = buildMediaPrompt(prompt, opts.media, workDir);
+      // Prompt is passed via stdin below. PR #11 comment thread noted that
+      // buildMediaPrompt injects newlines / special chars that break positional
+      // arg passing on Windows cmd.exe with shell:true. stdin side-steps that.
+      const args = ['run', '--format', 'json'];
       if (settings.showThoughts) args.push('--thinking');
 
       if (settings.workDir || opts.workDir) {
@@ -42,9 +74,12 @@ export class OpenCodeAdapter implements CLIAdapter {
 
       const proc = spawnProc(this.command, args, {
         cwd: settings.workDir || opts.workDir,
-        stdio: ['ignore', 'pipe', 'pipe'],
+        stdio: ['pipe', 'pipe', 'pipe'],
         env: { ...process.env },
       });
+
+      proc.stdin!.write(fullPrompt, 'utf8');
+      proc.stdin!.end();
 
       setupAbort(proc, opts.signal);
       const timer = setupTimeout(proc, opts.timeout);

--- a/src/bridge/router.ts
+++ b/src/bridge/router.ts
@@ -10,6 +10,7 @@ import { formatResponse } from './formatter.js';
 import type { WeixinMessage } from '../ilink/types.js';
 import type { BridgeConfig } from '../config.js';
 import type { AskUserRequest } from '../adapters/base.js';
+import type { DownloadedMedia } from '../utils/media.js';
 
 interface ActiveTask { abort: AbortController; tool: string }
 interface PendingQuestion { resolve: (answer: string) => void; timeout: ReturnType<typeof setTimeout>; toolName: string }
@@ -40,8 +41,8 @@ export class Router {
   }
 
   start(): void {
-    this.ilink.onMessage((msg, text, refText) => {
-      this.handle(msg, text, refText).catch((e) => log.error('路由异常:', e));
+    this.ilink.onMessage((msg, text, refText, media) => {
+      this.handle(msg, text, refText, media).catch((e) => log.error('路由异常:', e));
     });
   }
 
@@ -67,11 +68,21 @@ export class Router {
   }
 
 
-  private async handle(msg: WeixinMessage, text: string, refText: string): Promise<void> {
+  private async handle(msg: WeixinMessage, text: string, refText: string, media?: DownloadedMedia[]): Promise<void> {
     const uid = msg.from_user_id;
     if (this.config.allowedUsers.length > 0 && !this.config.allowedUsers.includes(uid)) return;
 
     const trimmed = text.trim();
+
+    // Build media context for CLI
+    let mediaContext = '';
+    if (media && media.length > 0) {
+      const mediaInfo = media.map(m => {
+        const typeNames: Record<string, string> = { image: '图片', file: '文件', video: '视频' };
+        return `${typeNames[m.type] || '媒体'}: ${m.fileName} (${m.path})`;
+      });
+      mediaContext = `\n\n[收到媒体文件]\n${mediaInfo.join('\n')}`;
+    }
 
     // ── /command ──
     if (trimmed.startsWith('/')) {
@@ -90,7 +101,7 @@ export class Router {
       if (t1 && t2 && this.registry.isAvailable(t1) && this.registry.isAvailable(t2)) {
         const busy = [t1, t2].find(t => this.active.has(`${uid}:${t}`));
         if (busy) { await this.ilink.sendText(uid, `${busy} 在忙`); return; }
-        await this.chain(uid, t1, t2, prompt);
+        await this.chain(uid, t1, t2, prompt + mediaContext, media);
         return;
       }
     }
@@ -108,8 +119,8 @@ export class Router {
       const toolName = this.getCli(uid, rest, refText);
       this.sessions.update(uid, { defaultTool: toolName });
       if (this.active.has(`${uid}:${toolName}`)) { await this.ilink.sendText(uid, `${toolName} 在忙`); return; }
-      const fullPrompt = `以下是 ${prev.tool} 的输出:\n\n${prev.text}\n\n---\n\n${prompt}`;
-      await this.exec(uid, toolName, fullPrompt);
+      const fullPrompt = `以下是 ${prev.tool} 的输出:\n\n${prev.text}\n\n---\n\n${prompt}${mediaContext}`;
+      await this.exec(uid, toolName, fullPrompt, media);
       return;
     }
 
@@ -149,8 +160,8 @@ export class Router {
     if (this.active.has(`${uid}:${toolName}`)) { await this.ilink.sendText(uid, `${toolName} 在忙`); return; }
 
     const prompt = atMatch ? atMatch[2].trim() : trimmed;
-    const combined = [prompt, refText].filter(Boolean).join('\n\n');
-    await this.exec(uid, toolName, combined);
+    const combined = [prompt, refText].filter(Boolean).join('\n\n') + mediaContext;
+    await this.exec(uid, toolName, combined, media);
   }
 
   // ─── /command → ALL are commands, never pass through ────
@@ -205,6 +216,7 @@ export class Router {
           '/files  列出目录结构',
           '/compact  压缩上下文(清session)',
           '/stats  使用统计',
+          '/send <文件路径>  发送文件到微信',
           '',
           '— 会话 —',
           '/new  新会话',
@@ -564,6 +576,35 @@ export class Router {
         return true;
       }
 
+      case 'send': {
+        if (!arg) {
+          await reply('/send <文件路径>\n发送本地文件到微信');
+          return true;
+        }
+        try {
+          const filePath = arg.trim();
+          const { existsSync } = await import('node:fs');
+          if (!existsSync(filePath)) {
+            await reply(`文件不存在: ${filePath}`);
+            return true;
+          }
+          const ext = filePath.split('.').pop()?.toLowerCase();
+          if (['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp'].includes(ext || '')) {
+            await this.ilink.sendImage(uid, filePath);
+            await reply(`已发送图片: ${filePath}`);
+          } else if (['mp4', 'mov', 'avi', 'mkv', 'webm'].includes(ext || '')) {
+            await this.ilink.sendVideo(uid, filePath);
+            await reply(`已发送视频: ${filePath}`);
+          } else {
+            await this.ilink.sendFile(uid, filePath);
+            await reply(`已发送文件: ${filePath}`);
+          }
+        } catch (err) {
+          await reply(`发送失败: ${(err as Error).message}`);
+        }
+        return true;
+      }
+
       case 'plan': {
         if (arg) {
           // /plan <description> → send plan request to tool
@@ -811,7 +852,7 @@ export class Router {
 
   // ─── Chain: tool1 → tool2 ─────────────────────────────
 
-  private async chain(uid: string, tool1: string, tool2: string, prompt: string): Promise<void> {
+  private async chain(uid: string, tool1: string, tool2: string, prompt: string, media?: DownloadedMedia[]): Promise<void> {
     const adapter1 = this.registry.get(tool1);
     const adapter2 = this.registry.get(tool2);
     if (!adapter1 || !adapter2) return;
@@ -825,7 +866,7 @@ export class Router {
     try {
       // Step 1: run tool1
       log.debug(`[chain] step1: ${tool1}`);
-      const { result: r1, notice: n1 } = await this.runOnce(tool1, uid, prompt, abort.signal);
+      const { result: r1, notice: n1 } = await this.runOnce(tool1, uid, prompt, abort.signal, media);
 
       if (abort.signal.aborted || r1.error) {
         if (!abort.signal.aborted) {
@@ -881,15 +922,22 @@ export class Router {
     uid: string,
     prompt: string,
     signal: AbortSignal,
+    media?: DownloadedMedia[],
   ): Promise<{ result: import('../adapters/base.js').ExecResult; notice: string }> {
     const adapter = this.registry.get(toolName)!;
     const extraArgs = this.config.tools[toolName]?.args;
     const hadSession = adapter.capabilities.sessionResume && !!this.sessions.get(uid).sessionIds[toolName];
 
     if (signal.aborted) return { result: { text: '已取消', error: true }, notice: '' };
-    const result = await adapter.execute(prompt, {
+    
+    // 追加 SEND_FILE 提示到 prompt
+    const sendFileHint = '\n\n[提示: 如果需要发送文件/图片到微信，在响应中包含标记 [SEND_FILE: 文件路径]]';
+    const enhancedPrompt = prompt + sendFileHint;
+    
+    const result = await adapter.execute(enhancedPrompt, {
       settings: this.sessions.get(uid), workDir: this.config.workDir, timeout: this.config.cliTimeout, extraArgs, signal,
       askUser: (req) => this.askUserViaWeChat(uid, toolName, req),
+      media,
     });
 
     if (result.sessionExpired && hadSession && !signal.aborted) {
@@ -955,7 +1003,7 @@ export class Router {
     return answers;
   }
 
-  private async exec(uid: string, toolName: string, prompt: string): Promise<void> {
+  private async exec(uid: string, toolName: string, prompt: string, media?: DownloadedMedia[]): Promise<void> {
     const adapter = this.registry.get(toolName);
     if (!adapter) return;
 
@@ -966,7 +1014,7 @@ export class Router {
     const settings = this.sessions.get(uid);
 
     try {
-      const { result, notice } = await this.runOnce(toolName, uid, prompt, abort.signal);
+      const { result, notice } = await this.runOnce(toolName, uid, prompt, abort.signal, media);
 
       if (abort.signal.aborted) return;
 
@@ -974,8 +1022,11 @@ export class Router {
         this.sessions.setSession(uid, toolName, result.sessionId);
       }
 
+      // Parse [SEND_FILE: path] markers and send files
+      const { text: cleanText, sentFiles } = await this.parseAndSendFiles(uid, result.text);
+
       // Store for >> relay; auto-switch defaultTool to last used tool
-      this.lastResponse.set(uid, { tool: adapter.displayName, text: result.text });
+      this.lastResponse.set(uid, { tool: adapter.displayName, text: cleanText });
       this.sessions.update(uid, { defaultTool: toolName });
 
       // Send thinking content first if enabled
@@ -983,7 +1034,11 @@ export class Router {
         await this.ilink.sendText(uid, `思考过程：\n\n${result.thinking}\n\n———`);
       }
 
-      await this.ilink.sendText(uid, formatResponse(notice + result.text, {
+      const sentNotice = sentFiles.length > 0
+        ? `\n[已发送文件: ${sentFiles.join(', ')}]`
+        : '';
+
+      await this.ilink.sendText(uid, formatResponse(notice + cleanText + sentNotice, {
         tool: adapter.displayName,
         duration: result.duration || (Date.now() - start),
         error: result.error,
@@ -997,5 +1052,46 @@ export class Router {
       stopTyping();
       this.active.delete(`${uid}:${toolName}`);
     }
+  }
+
+  private async parseAndSendFiles(uid: string, text: string): Promise<{ text: string; sentFiles: string[] }> {
+    const { existsSync } = await import('node:fs');
+    const sentFiles: string[] = [];
+    const regex = /\[SEND_FILE:\s*([^\]]+)\]/g;
+    let match;
+    const workDir = this.sessions.get(uid).workDir || this.config.workDir;
+
+    while ((match = regex.exec(text)) !== null) {
+      let filePath = match[1].trim();
+      
+      // 处理相对路径
+      if (!filePath.match(/^[A-Za-z]:/) && !filePath.startsWith('/')) {
+        filePath = join(workDir, filePath);
+      }
+
+      try {
+        if (!existsSync(filePath)) {
+          log.warn(`[SEND_FILE] 文件不存在: ${filePath}`);
+          continue;
+        }
+
+        const ext = filePath.split('.').pop()?.toLowerCase();
+        if (['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp'].includes(ext || '')) {
+          await this.ilink.sendImage(uid, filePath);
+        } else if (['mp4', 'mov', 'avi', 'mkv', 'webm'].includes(ext || '')) {
+          await this.ilink.sendVideo(uid, filePath);
+        } else {
+          await this.ilink.sendFile(uid, filePath);
+        }
+        sentFiles.push(filePath.split(/[\\/]/).pop() || filePath);
+        log.info(`[SEND_FILE] 已发送: ${filePath}`);
+      } catch (err) {
+        log.error(`[SEND_FILE] 发送失败: ${filePath}`, err);
+      }
+    }
+
+    // 移除标记
+    const cleanText = text.replace(regex, '').trim();
+    return { text: cleanText, sentFiles };
   }
 }

--- a/src/ilink/client.ts
+++ b/src/ilink/client.ts
@@ -1,7 +1,10 @@
-import { randomUUID } from 'node:crypto';
-import { generateWechatUin } from '../utils/crypto.js';
+import { randomUUID, randomBytes } from 'node:crypto';
+import { readFileSync, existsSync, statSync } from 'node:fs';
+import { basename } from 'node:path';
+import { generateWechatUin, encryptAesEcb, aesEcbPaddedSize, encodeMessageAesKey, md5 } from '../utils/crypto.js';
 import { log } from '../utils/logger.js';
 import { savePollCursor, loadPollCursor, saveContextTokens } from '../config.js';
+import { downloadImage, downloadFile, downloadVideo, type DownloadedMedia } from '../utils/media.js';
 import type {
   Credentials,
   WeixinMessage,
@@ -12,8 +15,19 @@ import type {
 
 const CHANNEL_VERSION = '1.0.2';
 const HTTP_TIMEOUT_MS = 45_000;
+const CDN_BASE_URL = 'https://novac2c.cdn.weixin.qq.com/c2c';
 
-export type MessageHandler = (msg: WeixinMessage, text: string, refText: string) => void;
+// Upload media types
+const UPLOAD_MEDIA_TYPE_IMAGE = 1;
+const UPLOAD_MEDIA_TYPE_VIDEO = 2;
+const UPLOAD_MEDIA_TYPE_FILE = 3;
+
+export type MessageHandler = (
+  msg: WeixinMessage,
+  text: string,
+  refText: string,
+  media?: DownloadedMedia[]
+) => void;
 
 export class ILinkClient {
   private credentials: Credentials;
@@ -70,7 +84,7 @@ export class ILinkClient {
         this.backoffMs = 1000;
 
         for (const msg of msgs) {
-          this.processMessage(msg);
+          await this.processMessage(msg);
         }
       } catch (err: unknown) {
         if (!this.running) return;
@@ -138,7 +152,7 @@ export class ILinkClient {
 
   // ─── Message handling ──────────────────────────────────
 
-  private processMessage(msg: WeixinMessage): void {
+  private async processMessage(msg: WeixinMessage): Promise<void> {
     // Only process user messages, skip bot echoes
     if (msg.message_type !== 1) return;
 
@@ -147,14 +161,14 @@ export class ILinkClient {
     saveContextTokens(this.contextTokens);
 
     log.debug(`[msg] item_list=${JSON.stringify(msg.item_list)}`);
-    const { text, refText } = parseMessage(msg);
-    if (!text && !refText) return;
+    const { text, refText, mediaItems } = await parseMessage(msg);
+    if (!text && !refText && mediaItems.length === 0) return;
 
-    log.debug(`收到 [${msg.from_user_id.substring(0, 12)}...]: ${text.substring(0, 60)}`);
+    log.debug(`收到 [${msg.from_user_id.substring(0, 12)}...]: ${text.substring(0, 60)}${mediaItems.length > 0 ? ` (+${mediaItems.length} media)` : ''}`);
 
     for (const handler of this.handlers) {
       try {
-        handler(msg, text, refText);
+        handler(msg, text, refText, mediaItems.length > 0 ? mediaItems : undefined);
       } catch (err) {
         log.error('消息处理器异常:', err);
       }
@@ -220,6 +234,175 @@ export class ILinkClient {
     if (data.ret !== undefined && data.ret !== 0) {
       throw new Error(`发送消息失败: ${data.errmsg || `ret=${data.ret}`}`);
     }
+  }
+
+  // ─── File/Image/Video Upload & Send ──────────────────────
+
+  async sendFile(userId: string, filePath: string, title?: string): Promise<void> {
+    const token = this.contextTokens.get(userId);
+    if (!token) {
+      log.error(`无法发送文件给 ${userId}: 缺少 context_token`);
+      return;
+    }
+
+    if (!existsSync(filePath)) {
+      throw new Error(`文件不存在: ${filePath}`);
+    }
+
+    const upload = await this.uploadToCdn(userId, filePath, UPLOAD_MEDIA_TYPE_FILE);
+    const fileName = title || basename(filePath);
+
+    await this.sendRawMessage(userId, token, [
+      {
+        type: 4,
+        file_item: {
+          file_name: fileName,
+          len: String(upload.rawsize),
+          media: {
+            encrypt_query_param: upload.downloadParam,
+            aes_key: encodeMessageAesKey(upload.aeskey),
+            encrypt_type: 1,
+          },
+        },
+      },
+    ]);
+
+    log.info(`[sendFile] 已发送: ${fileName}`);
+  }
+
+  async sendImage(userId: string, imagePath: string, caption?: string): Promise<void> {
+    const token = this.contextTokens.get(userId);
+    if (!token) {
+      log.error(`无法发送图片给 ${userId}: 缺少 context_token`);
+      return;
+    }
+
+    if (!existsSync(imagePath)) {
+      throw new Error(`图片不存在: ${imagePath}`);
+    }
+
+    if (caption) {
+      await this.sendText(userId, caption);
+    }
+
+    const upload = await this.uploadToCdn(userId, imagePath, UPLOAD_MEDIA_TYPE_IMAGE);
+
+    await this.sendRawMessage(userId, token, [
+      {
+        type: 2,
+        image_item: {
+          media: {
+            encrypt_query_param: upload.downloadParam,
+            aes_key: encodeMessageAesKey(upload.aeskey),
+            encrypt_type: 1,
+          },
+          mid_size: upload.filesize,
+        },
+      },
+    ]);
+
+    log.info(`[sendImage] 已发送图片: ${basename(imagePath)}`);
+  }
+
+  async sendVideo(userId: string, videoPath: string): Promise<void> {
+    const token = this.contextTokens.get(userId);
+    if (!token) {
+      log.error(`无法发送视频给 ${userId}: 缺少 context_token`);
+      return;
+    }
+
+    if (!existsSync(videoPath)) {
+      throw new Error(`视频不存在: ${videoPath}`);
+    }
+
+    const upload = await this.uploadToCdn(userId, videoPath, UPLOAD_MEDIA_TYPE_VIDEO);
+
+    await this.sendRawMessage(userId, token, [
+      {
+        type: 5,
+        video_item: {
+          media: {
+            encrypt_query_param: upload.downloadParam,
+            aes_key: encodeMessageAesKey(upload.aeskey),
+            encrypt_type: 1,
+          },
+          video_size: upload.filesize,
+        },
+      },
+    ]);
+
+    log.info(`[sendVideo] 已发送视频: ${basename(videoPath)}`);
+  }
+
+  private async uploadToCdn(
+    userId: string,
+    filePath: string,
+    mediaType: number,
+  ): Promise<{ rawsize: number; filesize: number; aeskey: Buffer; downloadParam: string }> {
+    const plaintext = readFileSync(filePath);
+    const rawsize = plaintext.length;
+    const rawfilemd5 = md5(plaintext);
+    const filesize = aesEcbPaddedSize(rawsize);
+
+    const filekey = randomBytes(16).toString('hex');
+    const aeskey = randomBytes(16);
+
+    // Get upload URL from iLink
+    const uploadResp = await fetch(
+      `${this.credentials.baseUrl}/ilink/bot/getuploadurl`,
+      {
+        method: 'POST',
+        headers: this.headers(),
+        body: JSON.stringify({
+          filekey,
+          media_type: mediaType,
+          to_user_id: userId,
+          rawsize,
+          rawfilemd5,
+          filesize,
+          aeskey: aeskey.toString('hex'),
+          no_need_thumb: true,
+          base_info: this.baseInfo(),
+        }),
+      },
+    );
+
+    if (!uploadResp.ok) {
+      const body = await uploadResp.text().catch(() => '');
+      throw new Error(`获取上传URL失败: HTTP ${uploadResp.status} ${body}`);
+    }
+
+    const uploadData = (await uploadResp.json()) as { upload_param?: string };
+    const uploadParam = uploadData.upload_param;
+    if (!uploadParam) {
+      throw new Error('获取上传URL失败: 无 upload_param');
+    }
+
+    // Encrypt and upload to CDN
+    const ciphertext = encryptAesEcb(plaintext, aeskey);
+    const cdnUrl = `${CDN_BASE_URL}/upload?encrypted_query_param=${encodeURIComponent(uploadParam)}&filekey=${encodeURIComponent(filekey)}`;
+
+    log.debug(`[upload] Uploading to CDN: ${rawsize} bytes`);
+
+    const cdnResp = await fetch(cdnUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/octet-stream' },
+      body: new Uint8Array(ciphertext),
+    });
+
+    if (!cdnResp.ok) {
+      const body = await cdnResp.text().catch(() => '');
+      throw new Error(`CDN 上传失败: HTTP ${cdnResp.status} ${body}`);
+    }
+
+    const downloadParam = cdnResp.headers.get('x-encrypted-param');
+    if (!downloadParam) {
+      throw new Error('CDN 上传失败: 无 x-encrypted-param');
+    }
+
+    log.debug(`[upload] CDN upload success, downloadParam: ${downloadParam.substring(0, 30)}...`);
+
+    return { rawsize, filesize, aeskey, downloadParam };
   }
 
   // ─── Typing indicator ─────────────────────────────────
@@ -301,14 +484,43 @@ export class ILinkClient {
 
 // ─── Helpers ───────────────────────────────────────────────
 
-function parseMessage(msg: WeixinMessage): { text: string; refText: string } {
+async function parseMessage(msg: WeixinMessage): Promise<{ text: string; refText: string; mediaItems: DownloadedMedia[] }> {
   const parts: string[] = [];
   let refText = '';
+  const mediaItems: DownloadedMedia[] = [];
+  
   for (const item of msg.item_list) {
     if (item.type === 1 && item.text_item?.text) {
       parts.push(item.text_item.text);
+    } else if (item.type === 2 && item.image_item) {
+      try {
+        const media = await downloadImage(item.image_item);
+        mediaItems.push(media);
+        parts.push(`[图片: ${media.fileName}]`);
+      } catch (err) {
+        log.error('[parseMessage] 下载图片失败:', err);
+        parts.push('[图片: 下载失败]');
+      }
     } else if (item.type === 3 && item.voice_item?.text) {
       parts.push(item.voice_item.text); // voice-to-text transcription
+    } else if (item.type === 4 && item.file_item) {
+      try {
+        const media = await downloadFile(item.file_item);
+        mediaItems.push(media);
+        parts.push(`[文件: ${media.fileName}]`);
+      } catch (err) {
+        log.error('[parseMessage] 下载文件失败:', err);
+        parts.push('[文件: 下载失败]');
+      }
+    } else if (item.type === 5 && item.video_item) {
+      try {
+        const media = await downloadVideo(item.video_item);
+        mediaItems.push(media);
+        parts.push(`[视频: ${media.fileName}]`);
+      } catch (err) {
+        log.error('[parseMessage] 下载视频失败:', err);
+        parts.push('[视频: 下载失败]');
+      }
     }
     // Extract quoted message content (WeChat 引用消息)
     const ref = item.ref_msg;
@@ -322,7 +534,7 @@ function parseMessage(msg: WeixinMessage): { text: string; refText: string } {
   }
   // WeChat embeds quoted content inline as "[引用]:\n<content>" — strip the prefix
   const text = parts.join('\n').trim().replace(/^\[引用\]:\n?/, '');
-  return { text, refText };
+  return { text, refText, mediaItems };
 }
 
 function chunkText(text: string, maxLen: number): string[] {

--- a/src/ilink/types.ts
+++ b/src/ilink/types.ts
@@ -13,6 +13,7 @@ export interface CDNMedia {
   encrypt_query_param: string;
   aes_key: string;
   encrypt_type?: number;
+  full_url?: string;
 }
 
 // ─── Message Items ─────────────────────────────────────────

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -1,4 +1,4 @@
-import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+import { createCipheriv, createDecipheriv, randomBytes, createHash } from 'node:crypto';
 
 export function encryptAesEcb(plaintext: Buffer, key: Buffer): Buffer {
   const cipher = createCipheriv('aes-128-ecb', key, null);
@@ -35,10 +35,21 @@ export function generateAesKey(): Buffer {
 }
 
 /**
+ * Encode AES key for message (hex -> base64)
+ */
+export function encodeMessageAesKey(aeskey: Buffer): string {
+  return Buffer.from(aeskey.toString('hex')).toString('base64');
+}
+
+/**
  * Generate X-WECHAT-UIN header value:
  * base64(String(random_uint32))
  */
 export function generateWechatUin(): string {
   const uint32 = randomBytes(4).readUInt32BE(0);
   return Buffer.from(String(uint32), 'utf-8').toString('base64');
+}
+
+export function md5(data: Buffer | string): string {
+  return createHash('md5').update(data).digest('hex');
 }

--- a/src/utils/media.ts
+++ b/src/utils/media.ts
@@ -1,0 +1,230 @@
+import { writeFileSync, mkdirSync, existsSync, unlinkSync, copyFileSync } from 'node:fs';
+import { join, basename } from 'node:path';
+import { homedir } from 'node:os';
+import { createDecipheriv } from 'node:crypto';
+import { log } from './logger.js';
+import type { CDNMedia, ImageItem, FileItem, VideoItem } from '../ilink/types.js';
+import { parseAesKey } from '../utils/crypto.js';
+
+const GLOBAL_MEDIA_DIR = join(homedir(), '.wx-ai-bridge', 'media');
+const WX_CDN_BASE = 'https://multimedia.nt.qq.com.cn';
+const WORK_MEDIA_SUBDIR = '.wx-media';
+
+export interface DownloadedMedia {
+  type: 'image' | 'file' | 'video';
+  path: string;
+  fileName: string;
+  mimeType?: string;
+  size?: number;
+}
+
+export function ensureMediaDir(workDir?: string): string {
+  const mediaDir = workDir ? join(workDir, WORK_MEDIA_SUBDIR) : GLOBAL_MEDIA_DIR;
+  if (!existsSync(mediaDir)) {
+    mkdirSync(mediaDir, { recursive: true });
+  }
+  return mediaDir;
+}
+
+export async function downloadMedia(
+  media: CDNMedia,
+  options: {
+    type: 'image' | 'file' | 'video';
+    fileName?: string;
+    mimeType?: string;
+    workDir?: string;
+  }
+): Promise<DownloadedMedia> {
+  const mediaDir = ensureMediaDir(options.workDir);
+  
+  const { encrypt_query_param, aes_key, encrypt_type, full_url } = media;
+  
+  log.debug(`[media] encrypt_query_param: ${encrypt_query_param?.substring(0, 100)}...`);
+  log.debug(`[media] aes_key: ${aes_key ? 'present' : 'none'}, encrypt_type: ${encrypt_type}, full_url: ${full_url ? 'present' : 'none'}`);
+  
+  // 优先使用 full_url（文件下载）
+  let url: string;
+  if (full_url) {
+    url = full_url;
+    log.debug(`[media] Using full_url for download`);
+  } else {
+    url = buildCdnUrl(encrypt_query_param);
+  }
+  
+  log.debug(`[media] Downloading from: ${url.substring(0, 100)}...`);
+  
+  const response = await fetch(url, {
+    headers: {
+      'User-Agent': 'MicroMessenger/6.0',
+    },
+  });
+  
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    log.error(`[media] HTTP ${response.status}: ${body.substring(0, 200)}`);
+    throw new Error(`Failed to download media: HTTP ${response.status}`);
+  }
+  
+  let data: Uint8Array = new Uint8Array(await response.arrayBuffer());
+  
+  // 微信 CDN 下载的文件都是加密的，需要解密
+  // aes_key 存在时必须解密
+  if (aes_key) {
+    try {
+      data = decryptMedia(Buffer.from(data), aes_key);
+      log.debug(`[media] Decrypted ${data.length} bytes`);
+    } catch (err) {
+      log.warn(`[media] Decrypt failed, file may not be encrypted: ${err}`);
+      // 解密失败可能是因为文件本身未加密，继续使用原始数据
+    }
+  }
+  
+  const fileName = options.fileName || generateFileName(options.type);
+  const filePath = join(mediaDir, fileName);
+  
+  writeFileSync(filePath, data);
+  
+  log.info(`[media] Saved: ${filePath} (${data.length} bytes)`);
+  
+  return {
+    type: options.type,
+    path: filePath,
+    fileName,
+    mimeType: options.mimeType,
+    size: data.length,
+  };
+}
+
+export async function downloadImage(item: ImageItem, workDir?: string): Promise<DownloadedMedia> {
+  const mediaDir = ensureMediaDir(workDir);
+  
+  // 优先使用 item.url（如果有）
+  if (item.url) {
+    log.debug(`[media] Using direct URL: ${item.url}`);
+    try {
+      const response = await fetch(item.url, {
+        headers: { 'User-Agent': 'MicroMessenger/6.0' },
+      });
+      if (response.ok) {
+        const fileName = extractFileNameFromUrl(item.url);
+        const filePath = join(mediaDir, fileName);
+        const data = new Uint8Array(await response.arrayBuffer());
+        writeFileSync(filePath, data);
+        log.info(`[media] Saved from URL: ${filePath} (${data.length} bytes)`);
+        return { type: 'image', path: filePath, fileName, size: data.length };
+      }
+    } catch (err) {
+      log.warn(`[media] Direct URL failed, trying CDN: ${err}`);
+    }
+  }
+  
+  return downloadMedia(item.media, {
+    type: 'image',
+    fileName: item.url ? extractFileNameFromUrl(item.url) : undefined,
+    workDir,
+  });
+}
+
+export async function downloadFile(item: FileItem, workDir?: string): Promise<DownloadedMedia> {
+  return downloadMedia(item.media, {
+    type: 'file',
+    fileName: item.file_name,
+    workDir,
+  });
+}
+
+export async function downloadVideo(item: VideoItem, workDir?: string): Promise<DownloadedMedia> {
+  return downloadMedia(item.media, {
+    type: 'video',
+    workDir,
+  });
+}
+
+function buildCdnUrl(encryptQueryParam: string): string {
+  if (encryptQueryParam.startsWith('http')) {
+    return encryptQueryParam;
+  }
+  return `${WX_CDN_BASE}/cdn?${encryptQueryParam}`;
+}
+
+function decryptMedia(data: Buffer, aesKeyBase64: string): Buffer {
+  const key = parseAesKey(aesKeyBase64);
+  
+  // 尝试 ECB 解密（微信 CDN 上传用的是 ECB）
+  try {
+    const decipherEcb = createDecipheriv('aes-128-ecb', key, null);
+    const decrypted = Buffer.concat([decipherEcb.update(data), decipherEcb.final()]);
+    // 检查解密结果是否像真实文件
+    const header = decrypted.slice(0, 4).toString('ascii');
+    if (header === '%PDF' || header === 'PK\x03\x04' || header.startsWith('\xd0\xcf') || header.startsWith('\x89PNG')) {
+      log.debug(`[media] ECB decryption successful, header: ${header}`);
+      return decrypted;
+    }
+  } catch {
+    // ECB 解密失败，尝试 CBC
+  }
+  
+  // 尝试 CBC 解密（IV 为全零）
+  const decipherCbc = createDecipheriv('aes-128-cbc', key, Buffer.alloc(16));
+  return Buffer.concat([decipherCbc.update(data), decipherCbc.final()]);
+}
+
+function generateFileName(type: 'image' | 'file' | 'video'): string {
+  const timestamp = Date.now();
+  const ext = type === 'image' ? 'jpg' : type === 'video' ? 'mp4' : 'bin';
+  return `${type}_${timestamp}.${ext}`;
+}
+
+function extractFileNameFromUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const pathParts = parsed.pathname.split('/');
+    return pathParts[pathParts.length - 1] || generateFileName('image');
+  } catch {
+    return generateFileName('image');
+  }
+}
+
+export function cleanupMedia(filePath: string): void {
+  try {
+    if (existsSync(filePath)) {
+      unlinkSync(filePath);
+      log.debug(`[media] Cleaned up: ${filePath}`);
+    }
+  } catch (err) {
+    log.warn(`[media] Failed to cleanup ${filePath}:`, err);
+  }
+}
+
+export function copyMediaToWorkDir(media: DownloadedMedia, workDir: string): DownloadedMedia {
+  if (!workDir || media.path.startsWith(workDir)) {
+    log.debug(`[media] No copy needed, workDir=${workDir}, media.path=${media.path}`);
+    return media;
+  }
+  
+  const mediaDir = ensureMediaDir(workDir);
+  const newPath = join(mediaDir, media.fileName);
+  
+  log.debug(`[media] Copying from ${media.path} to ${newPath}`);
+  
+  if (!existsSync(media.path)) {
+    log.error(`[media] Source file not found: ${media.path}`);
+    return media;
+  }
+  
+  try {
+    copyFileSync(media.path, newPath);
+    log.info(`[media] Copied to work dir: ${newPath}`);
+    return {
+      ...media,
+      path: newPath,
+    };
+  } catch (err) {
+    log.error(`[media] Failed to copy to work dir: ${err}`);
+    return media;
+  }
+}
+
+export function getGlobalMediaDir(): string {
+  return GLOBAL_MEDIA_DIR;
+}


### PR DESCRIPTION
## 功能概述

为 cli-in-wechat 添加完整的文件传输功能，支持微信和 CLI 工具之间收发文件。

## 新增功能

| 功能 | 说明 |
|------|------|
| 接收文件 | 微信发送的图片/文件/视频自动下载并传给 CLI 处理 |
| 发送文件 | \/send <路径>\ 命令发送本地文件到微信 |
| AI 触发发送 | AI 可通过 \[SEND_FILE: path]\ 标记发送文件 |

## 实现细节

- 新增 \src/utils/media.ts\: 媒体文件下载与解密工具
- 修改 \src/ilink/client.ts\: 添加 \sendFile\/\sendImage\/\sendVideo\ 方法
- 修改 \src/bridge/router.ts\: 
  - 新增 \/send\ 命令
  - 新增 \[SEND_FILE: path]\ 标记解析
- 修改所有适配器: 支持 \media\ 参数传递

## 技术要点

- 微信 CDN 文件使用 AES-128-ECB 加密/解密
- 文件自动复制到 \<workDir>/.wx-media/\ 便于 CLI 访问
- 支持相对路径和绝对路径

## 参考

文件上传实现参考了 [UNLINEARITY/CLI-WeChat-Bridge](https://github.com/UNLINEARITY/CLI-WeChat-Bridge)

## 测试

- [x] 微信发送文件到电脑
- [x] 电脑发送文件到微信 (\/send\ 命令)
- [x] AI 触发发送 (\[SEND_FILE: path]\ 标记)