### PR TITLE
feat: add /thoughts command to show AI thinking content

### DIFF
--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -36,6 +36,9 @@ export interface UserSettings {
   approvalMode: string;
   includeDirs: string;
   extensions: string;
+
+  // ── Output ──
+  showThoughts: boolean;
 }
 
 export const DEFAULT_SETTINGS: UserSettings = {
@@ -62,6 +65,7 @@ export const DEFAULT_SETTINGS: UserSettings = {
   approvalMode: '',
   includeDirs: '',
   extensions: '',
+  showThoughts: false,
 };
 
 export interface AskUserRequest {
@@ -83,6 +87,7 @@ export interface ExecOptions {
 
 export interface ExecResult {
   text: string;
+  thinking?: string;
   sessionId?: string;
   cost?: number;
   duration?: number;

--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -81,6 +81,7 @@ export class ClaudeAdapter implements CLIAdapter {
     log.debug(`[claude/sdk] effort=${settings.effort} mode=${settings.mode} resume=${sid || 'none'}`);
 
     let resultText = '';
+    let thinking = '';
     let sessionId: string | undefined;
     let error = false;
 
@@ -94,6 +95,17 @@ export class ClaudeAdapter implements CLIAdapter {
 
       const msg = message as Record<string, unknown>;
 
+      if (msg.type === 'assistant') {
+        const content = msg.content as Array<{ type: string; thinking?: string }> | undefined;
+        if (content) {
+          for (const block of content) {
+            if (block.type === 'thinking' && block.thinking) {
+              thinking += block.thinking;
+            }
+          }
+        }
+      }
+
       if (msg.type === 'result') {
         const result = msg as Record<string, unknown>;
         resultText = (result.result as string) || '(无输出)';
@@ -104,6 +116,7 @@ export class ClaudeAdapter implements CLIAdapter {
 
     return {
       text: resultText,
+      thinking: thinking || undefined,
       sessionId,
       duration: Date.now() - start,
       error,
@@ -115,7 +128,7 @@ export class ClaudeAdapter implements CLIAdapter {
   private executeWithCLI(prompt: string, opts: ExecOptions): Promise<ExecResult> {
     return new Promise((resolve) => {
       const { settings } = opts;
-      const args = ['-p', prompt, '--output-format', 'json'];
+      const args = ['-p', prompt, '--output-format', 'stream-json', '--thinking', 'enabled', '--verbose'];
 
       switch (settings.mode) {
         case 'auto': args.push('--dangerously-skip-permissions'); break;
@@ -128,7 +141,6 @@ export class ClaudeAdapter implements CLIAdapter {
       if (settings.allowedTools) args.push('--allowedTools', settings.allowedTools);
       if (settings.disallowedTools) args.push('--disallowedTools', settings.disallowedTools);
       if (settings.systemPrompt) args.push('--append-system-prompt', settings.systemPrompt);
-      if (settings.verbose) args.push('--verbose');
       if (settings.bare) args.push('--bare');
       if (settings.addDir) args.push('--add-dir', settings.addDir);
       if (settings.sessionName) args.push('--name', settings.sessionName);
@@ -152,14 +164,42 @@ export class ClaudeAdapter implements CLIAdapter {
       proc.on('close', (code) => {
         if (timer) clearTimeout(timer);
         if (opts.signal?.aborted) { resolve({ text: '已取消', error: true }); return; }
-        try {
-          const r = JSON.parse(stdout);
-          const isErr = r.is_error || r.subtype !== 'success';
-          const text = r.result || '(无输出)';
-          resolve({ text, sessionId: r.session_id, duration: r.duration_ms, error: isErr, sessionExpired: isErr && !!sid && isSessionError(text) });
-        } catch {
-          const text = stdout.trim() || stderr.trim() || `exit ${code}`;
-          resolve({ text, error: code !== 0, sessionExpired: code !== 0 && !!sid && isSessionError(text) });
+
+        let text = '';
+        let thinking = '';
+        let sessionId: string | undefined;
+        let duration: number | undefined;
+        let isErr = code !== 0;
+
+        const lines = stdout.trim().split('\n');
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          try {
+            const obj = JSON.parse(line);
+            if (obj.type === 'assistant' && obj.message?.content) {
+              for (const block of obj.message.content) {
+                if (block.type === 'thinking' && block.thinking) {
+                  thinking += block.thinking;
+                }
+                if (block.type === 'text' && block.text) {
+                  text += block.text;
+                }
+              }
+            }
+            if (obj.type === 'result') {
+              if (!text) text = obj.result || '(无输出)';
+              sessionId = obj.session_id;
+              duration = obj.duration_ms;
+              isErr = obj.is_error || obj.subtype !== 'success';
+            }
+          } catch { continue; }
+        }
+
+        if (text) {
+          resolve({ text, thinking: thinking || undefined, sessionId, duration, error: isErr, sessionExpired: isErr && !!sid && isSessionError(text) });
+        } else {
+          const fallbackText = stdout.trim() || stderr.trim() || `exit ${code}`;
+          resolve({ text: fallbackText, error: code !== 0, sessionExpired: code !== 0 && !!sid && isSessionError(fallbackText) });
         }
       });
       proc.on('error', (err) => { if (timer) clearTimeout(timer); resolve({ text: `无法启动: ${err.message}`, error: true }); });

--- a/src/adapters/opencode.ts
+++ b/src/adapters/opencode.ts
@@ -7,8 +7,8 @@ export class OpenCodeAdapter implements CLIAdapter {
   readonly displayName = 'OpenCode';
   readonly command = 'opencode';
   readonly capabilities: AdapterCapabilities = {
-    streaming: false, jsonOutput: true, sessionResume: false,
-    modes: ['auto'], hasEffort: false, hasModel: false, hasSearch: false, hasBudget: false,
+    streaming: false, jsonOutput: true, sessionResume: true,
+    modes: ['auto', 'safe', 'plan'], hasEffort: false, hasModel: true, hasSearch: false, hasBudget: false,
   };
 
   async isAvailable(): Promise<boolean> { return commandExists(this.command); }
@@ -16,16 +16,28 @@ export class OpenCodeAdapter implements CLIAdapter {
   execute(prompt: string, opts: ExecOptions): Promise<ExecResult> {
     return new Promise((resolve) => {
       const { settings } = opts;
-      // opencode -p "prompt" auto-approves all permissions
-      const args = ['-p', prompt, '-f', 'json', '-q'];
+      const args = ['run', prompt, '--format', 'json', '--thinking'];
 
       if (settings.workDir || opts.workDir) {
-        args.push('-c', settings.workDir || opts.workDir!);
+        args.push('--dir', settings.workDir || opts.workDir!);
+      }
+
+      if (settings.mode === 'auto') {
+        args.push('--dangerously-skip-permissions');
+      }
+
+      if (settings.model) {
+        args.push('-m', settings.model);
+      }
+
+      const sid = settings.sessionIds[this.name];
+      if (sid) {
+        args.push('-s', sid);
       }
 
       if (opts.extraArgs) args.push(...opts.extraArgs);
 
-      log.debug(`[opencode] executing`);
+      log.debug(`[opencode] executing: run --format json --thinking`);
 
       const proc = spawnProc(this.command, args, {
         cwd: settings.workDir || opts.workDir,
@@ -44,12 +56,40 @@ export class OpenCodeAdapter implements CLIAdapter {
       proc.on('close', (code) => {
         if (timer) clearTimeout(timer);
         if (opts.signal?.aborted) { resolve({ text: '已取消', error: true }); return; }
+
         try {
-          const r = JSON.parse(stdout);
-          resolve({
-            text: r.content || r.result || r.response || stdout.trim(),
-            error: !!r.error,
-          });
+          let text = '';
+          let thinking = '';
+          let sessionId: string | undefined;
+          let hasError = code !== 0;
+
+          const lines = stdout.trim().split('\n');
+          for (const line of lines) {
+            if (!line.trim()) continue;
+            try {
+              const obj = JSON.parse(line);
+              if (obj.type === 'text' && obj.part?.text) {
+                text += obj.part.text;
+              }
+              if (obj.type === 'reasoning' && obj.part?.text) {
+                thinking += obj.part.text;
+              }
+              if (obj.sessionID && !sessionId) {
+                sessionId = obj.sessionID;
+              }
+              if (obj.type === 'step_finish' && obj.part?.reason === 'error') {
+                hasError = true;
+              }
+            } catch {
+              // ignore parse errors for individual lines
+            }
+          }
+
+          if (text) {
+            resolve({ text, thinking: thinking || undefined, sessionId, error: hasError });
+          } else {
+            resolve({ text: stripAnsi(stdout.trim() || stderr.trim()) || `exit ${code}`, error: code !== 0 });
+          }
         } catch {
           resolve({ text: stripAnsi(stdout.trim() || stderr.trim()) || `exit ${code}`, error: code !== 0 });
         }

--- a/src/bridge/router.ts
+++ b/src/bridge/router.ts
@@ -193,6 +193,7 @@ export class Router {
           '/include <目录>  上下文(Gemini)',
           '/ext <名>  扩展(Gemini)',
           '/thinking  深度思考(Kimi)',
+          '/thoughts  显示AI思考内容',
           '',
           '— 操作 —',
           '/diff  查看git差异',
@@ -403,6 +404,13 @@ export class Router {
       case 'thinking': {
         this.sessions.update(uid, { thinking: !settings.thinking });
         await reply(`thinking → ${!settings.thinking ? 'ON (深度思考)' : 'OFF'}`);
+        return true;
+      }
+
+      case 'thoughts': {
+        const newValue = !settings.showThoughts;
+        this.sessions.update(uid, { showThoughts: newValue });
+        await reply(`thoughts → ${newValue ? '已开启 (将显示AI思考)' : '已关闭'}`);
         return true;
       }
 
@@ -925,6 +933,7 @@ export class Router {
     this.active.set(`${uid}:${toolName}`, { abort, tool: toolName });
     const stopTyping = await this.ilink.startTyping(uid);
     const start = Date.now();
+    const settings = this.sessions.get(uid);
 
     try {
       const { result, notice } = await this.runOnce(toolName, uid, prompt, abort.signal);
@@ -938,6 +947,11 @@ export class Router {
       // Store for >> relay; auto-switch defaultTool to last used tool
       this.lastResponse.set(uid, { tool: adapter.displayName, text: result.text });
       this.sessions.update(uid, { defaultTool: toolName });
+
+      // Send thinking content first if enabled
+      if (settings.showThoughts && result.thinking) {
+        await this.ilink.sendText(uid, `THINKING:\n\n${result.thinking}\n\n---`);
+      }
 
       await this.ilink.sendText(uid, formatResponse(notice + result.text, {
         tool: adapter.displayName,


### PR DESCRIPTION
## Summary
- Add /thoughts command to toggle showing AI thinking/reasoning content
- Claude adapter: capture thinking content in both SDK and CLI modes
  - CLI mode uses stream-json format with --thinking enabled
- OpenCode adapter: capture reasoning content with --thinking flag
- Thinking content sent separately with THINKING: prefix when enabled

## New Command
/thoughts - Toggle showing AI thinking content (ON/OFF)

## OpenCode Adapter Fixes (included)
- Use correct opencode run subcommand instead of incorrect -p flag
- Parse JSONL output format correctly
- Support session resume with -s flag
- Support model selection with -m flag
- Support auto mode with --dangerously-skip-permissions
- Support /resume command for listing historical sessions

## Testing
Tested with Claude Code and OpenCode, both showing thinking content correctly.