### PR TITLE
feat: improve iLink resilience and activity messaging

### DIFF
--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -4,6 +4,201 @@ import { commandExists, spawnProc, setupAbort, setupTimeout, isSessionError } fr
 import type { DownloadedMedia } from '../utils/media.js';
 import { copyMediaToWorkDir } from '../utils/media.js';
 
+function truncate(text: string, maxLen: number): string {
+  return text.length > maxLen ? `${text.substring(0, maxLen)}...` : text;
+}
+
+function basenameFromPath(pathLike: string): string {
+  const parts = pathLike.split(/[\\/]/).filter(Boolean);
+  return parts.length > 0 ? parts[parts.length - 1] : pathLike;
+}
+
+function asString(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value === null || value === undefined) return '';
+  if (Array.isArray(value)) return value.map(asString).filter(Boolean).join(' ');
+  if (typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    const preferred = ['text', 'output', 'result', 'content', 'message'];
+    for (const key of preferred) {
+      if (key in obj) {
+        const text = asString(obj[key]);
+        if (text) return text;
+      }
+    }
+    try {
+      return JSON.stringify(obj);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+}
+
+function pickStringField(obj: Record<string, unknown>, keys: string[]): string {
+  for (const key of keys) {
+    if (!(key in obj)) continue;
+    const value = asString(obj[key]).trim();
+    if (value) return value;
+  }
+  return '';
+}
+
+function summarizeToolUse(toolName: string, input: unknown): string {
+  const t = toolName || 'Tool';
+  const obj = (input && typeof input === 'object') ? (input as Record<string, unknown>) : {};
+
+  if (/^bash$/i.test(t)) {
+    const cmd = pickStringField(obj, ['command', 'cmd', 'script']);
+    return cmd
+      ? `- Shell Command: \`${truncate(cmd.replace(/\s+/g, ' ').trim(), 120)}\``
+      : '- Shell Command';
+  }
+
+  if (/^read$/i.test(t)) {
+    const path = pickStringField(obj, ['file_path', 'path', 'filePath']);
+    return path
+      ? `- Read File: \`${basenameFromPath(path)}\``
+      : '- Read File';
+  }
+
+  if (/^skill$/i.test(t)) {
+    const skill = pickStringField(obj, ['skill', 'name', 'skillName']);
+    return skill
+      ? `- Skill: \`${basenameFromPath(skill)}\``
+      : '- Skill';
+  }
+
+  if (/^glob$/i.test(t)) {
+    const pattern = pickStringField(obj, ['pattern', 'glob']);
+    return pattern
+      ? `- Glob: \`${truncate(pattern, 80)}\``
+      : '- Glob';
+  }
+
+  if (/^grep$/i.test(t)) {
+    const pattern = pickStringField(obj, ['pattern', 'query', 'regex']);
+    return pattern
+      ? `- Grep: \`${truncate(pattern, 80)}\``
+      : '- Grep';
+  }
+
+  if (/^ls$/i.test(t)) {
+    const path = pickStringField(obj, ['path', 'directory']);
+    return path
+      ? `- LS: \`${truncate(path, 80)}\``
+      : '- LS';
+  }
+
+  if (/^edit$/i.test(t)) {
+    const path = pickStringField(obj, ['file_path', 'path', 'filePath']);
+    return path
+      ? `- Edit File: \`${basenameFromPath(path)}\``
+      : '- Edit File';
+  }
+
+  if (/^write$/i.test(t)) {
+    const path = pickStringField(obj, ['file_path', 'path', 'filePath']);
+    return path
+      ? `- Write File: \`${basenameFromPath(path)}\``
+      : '- Write File';
+  }
+
+  if (/^multiedit$/i.test(t)) {
+    const path = pickStringField(obj, ['file_path', 'path', 'filePath']);
+    return path
+      ? `- MultiEdit: \`${basenameFromPath(path)}\``
+      : '- MultiEdit';
+  }
+
+  if (/^notebookread$/i.test(t)) {
+    const path = pickStringField(obj, ['notebook_path', 'path', 'file_path']);
+    return path
+      ? `- NotebookRead: \`${basenameFromPath(path)}\``
+      : '- NotebookRead';
+  }
+
+  if (/^notebookedit$/i.test(t)) {
+    const path = pickStringField(obj, ['notebook_path', 'path', 'file_path']);
+    return path
+      ? `- NotebookEdit: \`${basenameFromPath(path)}\``
+      : '- NotebookEdit';
+  }
+
+  if (/^webfetch$/i.test(t)) {
+    const url = pickStringField(obj, ['url', 'uri']);
+    return url
+      ? `- WebFetch: \`${truncate(url, 120)}\``
+      : '- WebFetch';
+  }
+
+  if (/^websearch$/i.test(t)) {
+    const query = pickStringField(obj, ['query', 'q', 'searchQuery']);
+    return query
+      ? `- WebSearch: \`${truncate(query, 100)}\``
+      : '- WebSearch';
+  }
+
+  if (/^(task|agent)$/i.test(t)) {
+    const sub = pickStringField(obj, ['agent', 'agent_type', 'subagent_type', 'name']);
+    const prompt = pickStringField(obj, ['description', 'prompt', 'task', 'instruction']);
+    if (sub && prompt) return `- ${t}: \`${sub}\` — ${truncate(prompt, 80)}`;
+    if (sub) return `- ${t}: \`${sub}\``;
+    if (prompt) return `- ${t}: ${truncate(prompt, 80)}`;
+    return `- ${t}`;
+  }
+
+  if (/^todowrite$/i.test(t)) {
+    return '- TodoWrite';
+  }
+
+  return `- ${t}`;
+}
+
+function summarizeToolResult(toolName: string | undefined, content: unknown): string {
+  const text = asString(content).replace(/\s+/g, ' ').trim();
+  if (!text) return '';
+
+  const tool = (toolName || '').toLowerCase();
+  if (tool === 'bash') {
+    const exit = text.match(/Exit code\s+(-?\d+)/i);
+    if (exit) return `  ↳ Exit: ${exit[1]}`;
+    if (/\bno output\b/i.test(text)) return '  ↳ Exit: no output';
+    return '';
+  }
+
+  if (tool === 'skill') {
+    const m = text.match(/Launching skill:\s*([^\s]+)/i);
+    if (m) return `  ↳ Launch: \`${m[1]}\``;
+    return '';
+  }
+
+  if (tool === 'webfetch') {
+    const status = text.match(/\b(?:HTTP|Status)\s*[: ]\s*(\d{3})/i);
+    if (status) return `  ↳ HTTP: ${status[1]}`;
+    return '';
+  }
+
+  if (tool === 'websearch') {
+    const n = text.match(/(\d+)\s+(?:result|results|条)/i);
+    if (n) return `  ↳ Results: ${n[1]}`;
+    return '';
+  }
+
+  if (tool === 'agent' || tool === 'task') {
+    if (/completed with no output/i.test(text)) return '  ↳ Completed';
+    if (/error/i.test(text)) return '  ↳ Error';
+    return '';
+  }
+
+  if (tool === 'read') {
+    return '';
+  }
+
+  // Default: do not dump raw result excerpts to avoid noisy/low-value spam.
+  return '';
+}
+
 function buildMediaPrompt(prompt: string, media?: DownloadedMedia[], workDir?: string): string {
   if (!media || media.length === 0) return prompt;
   
@@ -162,7 +357,11 @@ export class ClaudeAdapter implements CLIAdapter {
             if (block.type === 'tool_use') {
               pendingToolName = block.name;
               if (streamIntermediate) {
-                onIntermediate({ type: 'tool_use', content: '', toolName: block.name });
+                onIntermediate({
+                  type: 'tool_use',
+                  content: summarizeToolUse(block.name || 'Tool', block.input),
+                  toolName: block.name,
+                });
               }
             }
           }
@@ -176,11 +375,14 @@ export class ClaudeAdapter implements CLIAdapter {
         if (content && streamIntermediate) {
           for (const block of content) {
             if (block.type === 'tool_result' && block.content) {
-              onIntermediate({
-                type: 'tool_result',
-                content: block.content,
-                toolName: pendingToolName,
-              });
+              const summary = summarizeToolResult(pendingToolName, block.content);
+              if (summary) {
+                onIntermediate({
+                  type: 'tool_result',
+                  content: summary,
+                  toolName: pendingToolName,
+                });
+              }
               pendingToolName = undefined;
             }
           }

--- a/src/bridge/router.ts
+++ b/src/bridge/router.ts
@@ -9,7 +9,7 @@ import { SessionManager } from './session.js';
 import { formatResponse } from './formatter.js';
 import type { WeixinMessage } from '../ilink/types.js';
 import type { BridgeConfig } from '../config.js';
-import type { AskUserRequest } from '../adapters/base.js';
+import { DEFAULT_SETTINGS, type AskUserRequest, type MsgMode } from '../adapters/base.js';
 import type { DownloadedMedia } from '../utils/media.js';
 
 interface ActiveTask { abort: AbortController; tool: string }
@@ -65,6 +65,16 @@ export class Router {
       if (resolved && this.registry.isAvailable(resolved)) return resolved;
     }
     return this.sessions.get(uid).defaultTool || this.config.defaultTool;
+  }
+
+  private getDefaultMsgMode(): MsgMode {
+    return this.normalizeMsgMode(DEFAULT_SETTINGS.msgMode);
+  }
+
+  private normalizeMsgMode(mode?: string): MsgMode {
+    const v = (mode || '').toLowerCase();
+    if (v === 'verbose' || v === 'normal' || v === 'compact') return v;
+    return DEFAULT_SETTINGS.msgMode;
   }
 
 
@@ -193,7 +203,7 @@ export class Router {
           '/system <词>  追加系统提示',
           '/tools <列表>  允许工具',
           '/notool <列表>  禁用工具',
-          '/verbose  详细输出',
+          '/verbose  CLI详细输出(Kimi)',
           '/bare  跳过配置加载',
           '/adddir <路径>  额外目录',
           '/name <名>  会话命名',
@@ -206,7 +216,7 @@ export class Router {
           '/ext <名>  扩展(Gemini)',
           '/thinking  深度思考(Kimi)',
           '/thoughts  显示AI思考内容',
-          '/msgmode <verbose|normal|compact>  消息详细度',
+          '/msgmode <verbose|normal|compact|default>  消息详细度',
           '',
           '— 操作 —',
           '/diff  查看git差异',
@@ -241,6 +251,8 @@ export class Router {
 
       case 'status': case 'st': {
         const def = settings.defaultTool || this.config.defaultTool;
+        const currentMsgMode = this.normalizeMsgMode(settings.msgMode);
+        const defaultMsgMode = this.getDefaultMsgMode();
         const sids = Object.entries(settings.sessionIds).map(([k, v]) => `${k}:${String(v).substring(0, 8)}`).join(' ') || '无';
         const lines = [
           `工具: ${def}`,
@@ -251,7 +263,9 @@ export class Router {
           `budget: ${settings.maxBudget > 0 ? '$' + settings.maxBudget : '无限'}`,
           `sandbox: ${settings.sandbox || '无'}`,
           `search: ${settings.search ? 'ON' : 'OFF'}`,
-          `verbose: ${settings.verbose ? 'ON' : 'OFF'}`,
+          `msgMode: ${currentMsgMode} (默认: ${defaultMsgMode})`,
+          `thoughts: ${settings.showThoughts ? 'ON' : 'OFF'}`,
+          `cliVerbose: ${settings.verbose ? 'ON' : 'OFF'} (Kimi)`,
           `system: ${settings.systemPrompt ? settings.systemPrompt.substring(0, 40) + '...' : '无'}`,
           `dir: ${settings.workDir || this.config.workDir}`,
           `会话: ${sids}`,
@@ -374,7 +388,7 @@ export class Router {
 
       case 'verbose': case 'v':
         this.sessions.update(uid, { verbose: !settings.verbose });
-        await reply(`verbose → ${!settings.verbose ? 'ON' : 'OFF'}`);
+        await reply(`verbose(Kimi CLI) → ${!settings.verbose ? 'ON' : 'OFF'}`);
         return true;
 
       // ═══════════════════════════════════════════
@@ -429,34 +443,66 @@ export class Router {
       }
 
       case 'msgmode': {
-        const modes: Record<string, string> = {
+        const defaultMode = this.getDefaultMsgMode();
+        const currentMode = this.normalizeMsgMode(settings.msgMode);
+        const highRiskNow = currentMode === 'verbose' && !!settings.showThoughts;
+        const warning = '⚠️ 警告: 高频交互任务（如浏览器操作）不建议同时开启 /thoughts + /msgmode verbose，可能触发 iLink 限流，通常约 2-3 分钟恢复。';
+        const modes: Record<string, MsgMode> = {
           verbose: 'verbose',
           detailed: 'verbose',
           normal: 'normal',
           compact: 'compact',
           simple: 'compact',
         };
-        const v = modes[arg.toLowerCase()];
-        if (!v) {
+        if (!arg) {
           await reply([
-            `当前: ${settings.msgMode}`,
-            '/msgmode <verbose|normal|compact>',
+            `当前: ${currentMode}`,
+            `默认: ${defaultMode}`,
+            '/msgmode <verbose|normal|compact|default>',
             '',
-            'verbose - 显示中间文本 + 工具调用详情',
-            'normal  - 显示中间文本，不含工具调用',
-            'compact - 仅显示最终结果 (默认)',
+            'verbose - 流式显示文本 + Activity(含摘要)',
+            'normal  - 流式显示文本，Activity仅在最终结果展示',
+            'compact - 仅显示最终结果',
             '',
             '(思考内容由 /thoughts 控制)',
+            '',
+            warning,
+            `当前风险: ${highRiskNow ? '高' : '正常'}`,
           ].join('\n'));
           return true;
         }
-        this.sessions.update(uid, { msgMode: v as any });
-        const desc: Record<string, string> = {
-          verbose: 'VERBOSE\n显示中间文本 + 工具调用详情',
-          normal: 'NORMAL\n显示中间文本，不含工具调用',
-          compact: 'COMPACT\n仅显示最终结果',
+
+        const lower = arg.toLowerCase();
+        if (lower === 'default' || lower === 'reset') {
+          this.sessions.update(uid, { msgMode: defaultMode });
+          const risk = defaultMode === 'verbose' && !!settings.showThoughts ? '高' : '正常';
+          await reply(`msgmode: ${currentMode} → ${defaultMode}\n当前: ${defaultMode} | 默认: ${defaultMode}\n当前风险: ${risk}\n\n${warning}`);
+          return true;
+        }
+
+        const v = modes[lower];
+        if (!v) {
+          await reply(`无效 msgmode: ${arg}\n当前: ${currentMode}\n默认: ${defaultMode}\n/msgmode <verbose|normal|compact|default>`);
+          return true;
+        }
+
+        this.sessions.update(uid, { msgMode: v });
+        const desc: Record<MsgMode, string> = {
+          verbose: '流式显示文本 + Activity(含摘要)',
+          normal: '流式显示文本，Activity仅在最终结果展示',
+          compact: '仅显示最终结果',
         };
-        await reply(desc[v] + '\n\n(思考内容由 /thoughts 控制)');
+        const highRisk = v === 'verbose' && !!settings.showThoughts;
+        await reply([
+          `msgmode: ${currentMode} → ${v}`,
+          `当前: ${v} | 默认: ${defaultMode}`,
+          `当前风险: ${highRisk ? '高' : '正常'}`,
+          '',
+          desc[v],
+          '',
+          '(思考内容由 /thoughts 控制)',
+          ...(highRisk ? ['', warning] : []),
+        ].join('\n'));
         return true;
       }
 
@@ -513,7 +559,7 @@ export class Router {
           allowedTools: '', disallowedTools: '', verbose: false, sandbox: '',
           search: false, systemPrompt: '', workDir: '', bare: false, addDir: '',
           sessionName: '', ephemeral: false, profile: '', approvalMode: '',
-          includeDirs: '', extensions: '',
+          includeDirs: '', extensions: '', showThoughts: false, msgMode: this.getDefaultMsgMode(),
         } as any);
         await reply('所有设置已重置');
         return true;
@@ -1047,33 +1093,100 @@ export class Router {
     const stopTyping = await this.ilink.startTyping(uid);
     const start = Date.now();
     const settings = this.sessions.get(uid);
-    const msgMode = settings.msgMode || 'normal';
+    const msgMode = this.normalizeMsgMode(settings.msgMode);
 
     // Track if we've streamed text (to avoid duplicate with final result)
     let hasStreamedText = false;
+    let intermediateSendFailed = false;
+
+    // Serialize intermediate sends in-order to avoid burst/concurrency.
+    let sendQueue: Promise<void> = Promise.resolve();
+    const enqueueIntermediateSend = (text: string): void => {
+      if (!text.trim()) return;
+      sendQueue = sendQueue
+        .then(() => this.ilink.sendText(uid, text, { streamType: 'intermediate' }))
+        .catch((err) => {
+          intermediateSendFailed = true;
+          log.error(`[${toolName}] 发送中间消息失败:`, err);
+        });
+    };
+
+    // Keep text/thinking and tool activity as two independent streams.
+    // This allows tool blocks to be sent as standalone messages while preserving order.
+    const textLines: string[] = [];
+    const activityLines: string[] = [];
+    const finalActivityLines: string[] = [];
+    let textFlushTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const flushTextBatch = (): void => {
+      if (textFlushTimer) {
+        clearTimeout(textFlushTimer);
+        textFlushTimer = null;
+      }
+      if (textLines.length === 0) return;
+      const payload = textLines.join('\n\n');
+      textLines.length = 0;
+      enqueueIntermediateSend(payload);
+    };
+
+    const flushActivityBatch = (): void => {
+      if (msgMode !== 'verbose') {
+        activityLines.length = 0;
+        return;
+      }
+      if (activityLines.length === 0) return;
+      const payload = ['Activity', ...activityLines].join('\n');
+      activityLines.length = 0;
+      enqueueIntermediateSend(payload);
+    };
+
+    const scheduleTextFlush = (): void => {
+      if (textFlushTimer) clearTimeout(textFlushTimer);
+      textFlushTimer = setTimeout(() => {
+        textFlushTimer = null;
+        flushTextBatch();
+      }, 2500);
+    };
 
     // Streaming intermediate messages (for verbose/normal mode)
     const onIntermediate = msgMode !== 'compact' ? (msg: import('../adapters/base.js').IntermediateMessage) => {
-      // Send each block immediately when received
+      const content = typeof msg.content === 'string' ? msg.content.trim() : '';
       switch (msg.type) {
         case 'tool_use':
-          this.ilink.sendText(uid, `🔧 ${msg.toolName || 'tool'}...`).catch(() => {});
+          if (msgMode === 'normal') {
+            finalActivityLines.push(content || `- ${msg.toolName || 'Tool'}`);
+          } else if (msgMode === 'verbose') {
+            // Boundary: flush pending text first, then append activity.
+            flushTextBatch();
+            if (content) {
+              activityLines.push(content);
+            } else {
+              activityLines.push(`- ${msg.toolName || 'Tool'}`);
+            }
+          }
           break;
         case 'thinking':
           // thinking 显示只由 showThoughts 控制，与 msgMode 无关
-          if (settings.showThoughts && msg.content.trim()) {
-            this.ilink.sendText(uid, `💭 ${msg.content}`).catch(() => {});
+          if (settings.showThoughts && content) {
+            // Boundary: flush pending activity first, then append text.
+            flushActivityBatch();
+            textLines.push(`💭 ${content}`);
+            scheduleTextFlush();
           }
           break;
         case 'text':
-          if (msg.content.trim()) {
+          if (content) {
             hasStreamedText = true;
-            this.ilink.sendText(uid, msg.content).catch(() => {});
+            // Boundary: flush pending activity first, then append text.
+            flushActivityBatch();
+            textLines.push(content);
+            scheduleTextFlush();
           }
           break;
         case 'tool_result':
-          if (msgMode === 'verbose' && msg.content.trim()) {
-            this.ilink.sendText(uid, `📤 ${msg.content}`).catch(() => {});
+          if (msgMode === 'verbose' && content) {
+            flushTextBatch();
+            activityLines.push(content);
           }
           break;
       }
@@ -1081,6 +1194,11 @@ export class Router {
 
     try {
       const { result, notice } = await this.runOnce(toolName, uid, prompt, abort.signal, media, onIntermediate);
+
+      // Ensure all buffered intermediate content is emitted before final response.
+      flushTextBatch();
+      flushActivityBatch();
+      await sendQueue;
 
       if (abort.signal.aborted) return;
 
@@ -1104,16 +1222,23 @@ export class Router {
         ? `\n[已发送文件: ${sentFiles.join(', ')}]`
         : '';
 
-      // If text was already streamed, only send footer (avoid duplicate)
+      const finalActivityBlock = msgMode === 'normal' && finalActivityLines.length > 0
+        ? `Activity\n${finalActivityLines.join('\n')}\n\n`
+        : '';
+
+      // If text was already streamed, only send footer (avoid duplicate large-body resend).
       if (hasStreamedText) {
-        await this.ilink.sendText(uid, formatResponse(notice + sentNotice, {
+        const tailNotice = intermediateSendFailed
+          ? `${notice}[部分中间消息发送失败]${sentNotice}`
+          : `${notice}${sentNotice}`;
+        await this.ilink.sendText(uid, formatResponse(`${finalActivityBlock}${tailNotice}`.trim(), {
           tool: adapter.displayName,
           duration: result.duration || (Date.now() - start),
           error: result.error,
         }));
       } else {
         // compact mode or no streamed text: send full result
-        await this.ilink.sendText(uid, formatResponse(notice + cleanText + sentNotice, {
+        await this.ilink.sendText(uid, formatResponse(`${finalActivityBlock}${notice}${cleanText}${sentNotice}`, {
           tool: adapter.displayName,
           duration: result.duration || (Date.now() - start),
           error: result.error,
@@ -1125,6 +1250,8 @@ export class Router {
         await this.ilink.sendText(uid, `失败: ${(err as Error).message}`);
       }
     } finally {
+      // Defensive cleanup for pending timer when task exits early.
+      if (textFlushTimer) clearTimeout(textFlushTimer);
       stopTyping();
       this.active.delete(`${uid}:${toolName}`);
     }

--- a/src/ilink/client.ts
+++ b/src/ilink/client.ts
@@ -16,11 +16,20 @@ import type {
 const CHANNEL_VERSION = '1.0.2';
 const HTTP_TIMEOUT_MS = 45_000;
 const CDN_BASE_URL = 'https://novac2c.cdn.weixin.qq.com/c2c';
+const SEND_RETRY_DELAYS_MS = [12_000, 30_000] as const;
+const RATE_LIMIT_COOLDOWN_MS = 150_000; // ~2.5 minutes
 
 // Upload media types
 const UPLOAD_MEDIA_TYPE_IMAGE = 1;
 const UPLOAD_MEDIA_TYPE_VIDEO = 2;
 const UPLOAD_MEDIA_TYPE_FILE = 3;
+
+type SendStreamType = 'regular' | 'intermediate';
+
+interface UserRateLimitState {
+  consecutiveRet2: number;
+  suppressIntermediateUntil: number;
+}
 
 export type MessageHandler = (
   msg: WeixinMessage,
@@ -36,6 +45,8 @@ export class ILinkClient {
   private contextTokens = new Map<string, string>();
   private typingTickets = new Map<string, { ticket: string; ts: number }>();
   private handlers: MessageHandler[] = [];
+  private sendQueues = new Map<string, Promise<void>>();
+  private rateLimitStates = new Map<string, UserRateLimitState>();
   private backoffMs = 1000;
   private abortController: AbortController | null = null;
 
@@ -181,23 +192,97 @@ export class ILinkClient {
 
   // ─── Sending ───────────────────────────────────────────
 
-  async sendText(userId: string, text: string): Promise<void> {
+  private enqueueSend(userId: string, task: () => Promise<void>): Promise<void> {
+    const prev = this.sendQueues.get(userId) || Promise.resolve();
+    const run = prev.then(task, task);
+    const tracked = run.catch(() => {});
+    this.sendQueues.set(userId, tracked);
+    return run.finally(() => {
+      if (this.sendQueues.get(userId) === tracked) {
+        this.sendQueues.delete(userId);
+      }
+    });
+  }
+
+  private getRateLimitState(userId: string): UserRateLimitState {
+    const state = this.rateLimitStates.get(userId) || { consecutiveRet2: 0, suppressIntermediateUntil: 0 };
+    this.rateLimitStates.set(userId, state);
+    return state;
+  }
+
+  private isRateLimitedError(err: unknown): boolean {
+    const msg = err instanceof Error ? err.message : String(err);
+    return msg.includes('ret=-2');
+  }
+
+  async sendText(userId: string, text: string, options?: { streamType?: SendStreamType }): Promise<void> {
     const token = this.contextTokens.get(userId);
     if (!token) {
       log.error(`无法发送给 ${userId}: 缺少 context_token (用户必须先发一条消息)`);
       return;
     }
+    const streamType = options?.streamType || 'regular';
+    const state = this.getRateLimitState(userId);
+    if (streamType === 'intermediate' && Date.now() < state.suppressIntermediateUntil) {
+      log.debug(`[send] 跳过中间消息(保护模式): ${userId.substring(0, 12)}...`);
+      return;
+    }
 
-    const chunks = chunkText(text, 2000);
-    log.debug(`发送给 [${userId.substring(0, 12)}...] (${chunks.length} 块): ${text.substring(0, 100)}${text.length > 100 ? '…' : ''}`);
-    for (let i = 0; i < chunks.length; i++) {
-      await this.sendRawMessage(userId, token, [
-        { type: 1 as const, text_item: { text: chunks[i] } },
-      ]);
-      if (i < chunks.length - 1) {
-        await sleep(300); // preserve ordering between chunks
+    await this.enqueueSend(userId, async () => {
+      const chunks = chunkText(text, 2000);
+      log.debug(`发送给 [${userId.substring(0, 12)}...] (${chunks.length} 块): ${text.substring(0, 100)}${text.length > 100 ? '…' : ''}`);
+      for (let i = 0; i < chunks.length; i++) {
+        await this.sendRawMessageWithRetry(userId, token, [
+          { type: 1 as const, text_item: { text: chunks[i] } },
+        ], streamType);
+      }
+    });
+  }
+
+  private async sendRawMessageWithRetry(
+    userId: string,
+    contextToken: string,
+    itemList: MessageItem[],
+    streamType: SendStreamType = 'regular',
+  ): Promise<void> {
+    const state = this.getRateLimitState(userId);
+    let lastErr: unknown = null;
+    const maxAttempts = SEND_RETRY_DELAYS_MS.length + 1;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      if (attempt > 0) {
+        await sleep(SEND_RETRY_DELAYS_MS[attempt - 1]);
+      }
+
+      if (streamType === 'intermediate' && Date.now() < state.suppressIntermediateUntil) {
+        log.debug(`[send] 中间消息重试前进入保护模式，放弃本条发送`);
+        return;
+      }
+
+      try {
+        await this.sendRawMessage(userId, contextToken, itemList);
+        state.consecutiveRet2 = 0;
+        return;
+      } catch (err) {
+        lastErr = err;
+        const isRateLimited = this.isRateLimitedError(err);
+
+        if (isRateLimited) {
+          state.consecutiveRet2 += 1;
+          if (state.consecutiveRet2 >= 2) {
+            const until = Date.now() + RATE_LIMIT_COOLDOWN_MS;
+            state.suppressIntermediateUntil = Math.max(state.suppressIntermediateUntil, until);
+            log.warn(`[send] 已进入中间消息保护模式，约 ${Math.round(RATE_LIMIT_COOLDOWN_MS / 1000)}s`);
+          }
+        }
+
+        if (!isRateLimited || attempt === maxAttempts - 1) {
+          throw err;
+        }
+        log.warn(`[send] 命中速率限制 ret=-2，延迟重试 (${attempt + 1}/${maxAttempts - 1})`);
       }
     }
+    throw lastErr instanceof Error ? lastErr : new Error('发送消息失败');
   }
 
   private async sendRawMessage(
@@ -252,20 +337,22 @@ export class ILinkClient {
     const upload = await this.uploadToCdn(userId, filePath, UPLOAD_MEDIA_TYPE_FILE);
     const fileName = title || basename(filePath);
 
-    await this.sendRawMessage(userId, token, [
-      {
-        type: 4,
-        file_item: {
-          file_name: fileName,
-          len: String(upload.rawsize),
-          media: {
-            encrypt_query_param: upload.downloadParam,
-            aes_key: encodeMessageAesKey(upload.aeskey),
-            encrypt_type: 1,
+    await this.enqueueSend(userId, async () => {
+      await this.sendRawMessageWithRetry(userId, token, [
+        {
+          type: 4,
+          file_item: {
+            file_name: fileName,
+            len: String(upload.rawsize),
+            media: {
+              encrypt_query_param: upload.downloadParam,
+              aes_key: encodeMessageAesKey(upload.aeskey),
+              encrypt_type: 1,
+            },
           },
         },
-      },
-    ]);
+      ]);
+    });
 
     log.info(`[sendFile] 已发送: ${fileName}`);
   }
@@ -287,19 +374,21 @@ export class ILinkClient {
 
     const upload = await this.uploadToCdn(userId, imagePath, UPLOAD_MEDIA_TYPE_IMAGE);
 
-    await this.sendRawMessage(userId, token, [
-      {
-        type: 2,
-        image_item: {
-          media: {
-            encrypt_query_param: upload.downloadParam,
-            aes_key: encodeMessageAesKey(upload.aeskey),
-            encrypt_type: 1,
+    await this.enqueueSend(userId, async () => {
+      await this.sendRawMessageWithRetry(userId, token, [
+        {
+          type: 2,
+          image_item: {
+            media: {
+              encrypt_query_param: upload.downloadParam,
+              aes_key: encodeMessageAesKey(upload.aeskey),
+              encrypt_type: 1,
+            },
+            mid_size: upload.filesize,
           },
-          mid_size: upload.filesize,
         },
-      },
-    ]);
+      ]);
+    });
 
     log.info(`[sendImage] 已发送图片: ${basename(imagePath)}`);
   }
@@ -317,19 +406,21 @@ export class ILinkClient {
 
     const upload = await this.uploadToCdn(userId, videoPath, UPLOAD_MEDIA_TYPE_VIDEO);
 
-    await this.sendRawMessage(userId, token, [
-      {
-        type: 5,
-        video_item: {
-          media: {
-            encrypt_query_param: upload.downloadParam,
-            aes_key: encodeMessageAesKey(upload.aeskey),
-            encrypt_type: 1,
+    await this.enqueueSend(userId, async () => {
+      await this.sendRawMessageWithRetry(userId, token, [
+        {
+          type: 5,
+          video_item: {
+            media: {
+              encrypt_query_param: upload.downloadParam,
+              aes_key: encodeMessageAesKey(upload.aeskey),
+              encrypt_type: 1,
+            },
+            video_size: upload.filesize,
           },
-          video_size: upload.filesize,
         },
-      },
-    ]);
+      ]);
+    });
 
     log.info(`[sendVideo] 已发送视频: ${basename(videoPath)}`);
   }


### PR DESCRIPTION
## Summary
- harden iLink send path with per-user send queue and adaptive ret=-2 handling (delayed retries + temporary intermediate-message suppression)
- refactor intermediate output flow into Activity/text channels with clearer msgmode behavior
- add structured Claude tool activity summaries (Bash/Read/Skill/WebFetch/WebSearch/etc.) and prevent SDK fallback caused by non-string tool_result payloads
- improve /msgmode and /status UX: show current/default mode, show thoughts state, clarify warnings for verbose+thoughts under high-frequency tasks
- clarify /verbose command meaning (Kimi CLI verbosity) to avoid confusion with /msgmode

## Verification
- npm run typecheck
- npm run build

## Notes
- This branch is intentionally clean and contains only one commit on top of upstream/main.