### PR TITLE
fix(net): resilient WeChat fetch layer (#18) + audit-driven hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,11 @@ jobs:
         run: npm run build
 
       - name: Run unit tests
+        # Invoke node directly under bash so the shell expands test/*.test.ts on every OS.
+        # Going through `npm test` re-spawns via cmd.exe on Windows (no globbing), and
+        # Node 18's --test (unlike Node 21+) can't glob itself -> "Could not find test/*.test.ts".
         shell: bash
-        run: npm test
+        run: node --import tsx --test test/*.test.ts
 
       - name: Test module loading
         run: node -e "import('./dist/adapters/registry.js').then(m => { const r = new m.AdapterRegistry(); console.log('Registry OK, adapters:', r.getAll().map(a => a.name).join(', ')); })"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,10 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Run unit tests
+        shell: bash
+        run: npm test
+
       - name: Test module loading
         run: node -e "import('./dist/adapters/registry.js').then(m => { const r = new m.AdapterRegistry(); console.log('Registry OK, adapters:', r.getAll().map(a => a.name).join(', ')); })"
 

--- a/README.md
+++ b/README.md
@@ -197,12 +197,35 @@ Claude Code 需要你做选择时，问题自动转发到微信：
   "defaultTool": "claude",
   "workDir": "/Users/you",
   "cliTimeout": 300000,
-  "allowedUsers": [],
+  "allowedUsers": [],        // 见下方「安全」说明，留空 = 任何人可控制
   "tools": {
     "claude": { "args": ["--max-turns", "50"] }
   }
 }
 ```
+
+> **安全：`allowedUsers` 留空意味着任何能私聊机器人的微信好友都能以完整权限运行 CLI。**
+> 建议填入你自己的 `ilink_user_id`（启动日志会提示）。
+
+## 网络与代理（故障排查）
+
+所有对微信接口的请求都带 **超时 + 指数退避抖动重试 + 可读诊断**。瞬时网络抖动
+（如 `read ECONNRESET`、`fetch failed`）会被自动重试吞掉，不再像以前那样启动即崩
+（[issue #18](https://github.com/sgaofen/cli-in-wechat/issues/18)）。
+
+- **代理**：Node 的全局 `fetch` 默认不读代理环境变量。若你需要走代理访问微信，
+  设置 `HTTPS_PROXY`（或 `HTTP_PROXY` / `ALL_PROXY`）并安装可选依赖 `undici`：
+
+  ```bash
+  npm i undici                 # 启用代理支持（可选依赖）
+  export HTTPS_PROXY=http://127.0.0.1:7890
+  npm run dev
+  ```
+
+- **仍然 `ECONNRESET` / `fetch failed`**：确认本机可访问 `ilinkai.weixin.qq.com`；
+  尝试关闭/更换代理或 VPN；用 `npm run dev:debug` 查看带诊断的日志。
+- **会话过期自动重登**：token 失效（errcode -14/-13）时会自动重新出示 QR 码重登，
+  而不是直接退出。
 
 ## 架构
 
@@ -219,15 +242,20 @@ src/
 │   ├── claude.ts         # Agent SDK + CLI 降级
 │   ├── codex.ts          # codex exec + stdin 传参
 │   ├── gemini.ts         # gemini -p + stdin 传参
-│   ├── kimi.ts           # kimi --print + --thinking
+│   ├── kimi.ts           # kimi --print + stdin 传参 (避免 shell 注入)
 │   ├── opencode.ts       # opencode -p -f json
 │   └── registry.ts       # 自动检测已安装工具
-└── bridge/               # 桥接逻辑
-    ├── session.ts        # 会话持久化
-    ├── formatter.ts      # 响应格式化
-    └── router.ts         # @ 路由 + / 命令 + >> 接力 + 链式调用
-                          # + /resume 历史会话浏览
-                          # + AskUserQuestion 微信转发
+├── bridge/               # 桥接逻辑
+│   ├── session.ts        # 会话持久化 (原子写)
+│   ├── formatter.ts      # 响应格式化
+│   └── router.ts         # @ 路由 + / 命令 + >> 接力 + 链式调用
+│                         # + /resume 历史会话浏览
+│                         # + AskUserQuestion 微信转发
+└── utils/               # 工具库
+    ├── http.ts           # 带超时/重试/代理的 fetch (issue #18)
+    ├── media.ts          # 媒体下载 + AES 解密 + 文件名净化
+    ├── crypto.ts         # AES-ECB / 签名工具
+    └── logger.ts         # 分级日志
 ```
 
 ## 微信 iLink Bot API

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,9 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "undici": "^6.21.0"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
@@ -932,6 +935,16 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -8,17 +8,25 @@
     "cli-in-wechat": "dist/index.js",
     "wcli": "dist/index.js"
   },
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "scripts": {
     "dev": "tsx src/index.ts",
     "dev:debug": "tsx src/index.ts --debug",
     "build": "tsc",
+    "prepare": "npm run build",
     "start": "node dist/index.js",
     "typecheck": "tsc --noEmit",
-    "test": "node --test test/*.test.ts"
+    "test": "node --import tsx --test test/*.test.ts"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.81",
     "qrcode-terminal": "^0.12.0"
+  },
+  "optionalDependencies": {
+    "undici": "^6.21.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess } from 'node:child_process';
 import { log } from '../utils/logger.js';
-import type { DownloadedMedia } from '../utils/media.js';
+import { copyMediaToWorkDir, type DownloadedMedia } from '../utils/media.js';
 
 export type ToolMode = 'auto' | 'safe' | 'plan';
 export type MsgMode = 'verbose' | 'normal' | 'compact';
@@ -146,13 +146,75 @@ export function commandExists(cmd: string): Promise<boolean> {
   return new Promise((resolve) => { const proc = spawn(checker, [cmd], { stdio: 'pipe' }); proc.on('close', (code) => resolve(code === 0)); proc.on('error', () => resolve(false)); });
 }
 
+/** Terminate a spawned process. On Windows, spawnProc uses shell:true (cmd.exe wrapper),
+ *  so proc.kill() only reaps cmd.exe and orphans the real CLI child — use taskkill /T to
+ *  kill the whole tree. On POSIX a SIGTERM to the child is sufficient. */
+export function killProc(proc: ChildProcess): void {
+  if (proc.killed || proc.exitCode !== null) return;
+  if (WIN && proc.pid) {
+    try {
+      const killer = spawn('taskkill', ['/pid', String(proc.pid), '/T', '/F'], { stdio: 'ignore' });
+      killer.on('error', () => { try { proc.kill('SIGKILL'); } catch { /* ignore */ } });
+      return;
+    } catch { /* fall through to proc.kill */ }
+  }
+  try { proc.kill('SIGTERM'); } catch { /* already gone */ }
+}
+
 export function setupAbort(proc: ChildProcess, signal?: AbortSignal): void {
-  if (!signal) return; if (signal.aborted) { proc.kill('SIGTERM'); return; }
-  const onAbort = () => proc.kill('SIGTERM'); signal.addEventListener('abort', onAbort, { once: true }); proc.on('close', () => signal.removeEventListener('abort', onAbort));
+  if (!signal) return; if (signal.aborted) { killProc(proc); return; }
+  const onAbort = () => killProc(proc); signal.addEventListener('abort', onAbort, { once: true }); proc.on('close', () => signal.removeEventListener('abort', onAbort));
 }
 
 export function setupTimeout(proc: ChildProcess, timeout?: number): ReturnType<typeof setTimeout> | null {
-  if (!timeout) return null; return setTimeout(() => proc.kill('SIGTERM'), timeout);
+  if (!timeout) return null; return setTimeout(() => killProc(proc), timeout);
+}
+
+/** Attach a UTF-8 string decoder to a child's stdout/stderr so multibyte characters
+ *  (Chinese/emoji) are never split across data chunks and mangled into U+FFFD. */
+export function collectUtf8(proc: ChildProcess): { stdout: () => string; stderr: () => string } {
+  let out = '', err = '';
+  proc.stdout?.setEncoding('utf8');
+  proc.stderr?.setEncoding('utf8');
+  proc.stdout?.on('data', (c: string) => { out += c; });
+  proc.stderr?.on('data', (c: string) => { err += c; });
+  return { stdout: () => out, stderr: () => err };
+}
+
+/** Write a prompt to a child's stdin, swallowing the benign EPIPE that occurs if the
+ *  child closes stdin before we finish writing (otherwise it crashes the whole bridge). */
+export function writeStdin(proc: ChildProcess, data: string): void {
+  if (!proc.stdin) return;
+  proc.stdin.on('error', (e) => log.debug('[spawn] stdin write error (ignored):', (e as Error).message));
+  proc.stdin.write(data, 'utf8');
+  proc.stdin.end();
+}
+
+/** Shared media-prompt builder. Previously duplicated verbatim across all five adapters,
+ *  which forced multi-file edits for a single wording change (commit 9c84af6). */
+export function buildMediaPrompt(prompt: string, media?: DownloadedMedia[], workDir?: string): string {
+  if (!media || media.length === 0) return prompt;
+
+  const copiedMedia = workDir ? media.map((m) => copyMediaToWorkDir(m, workDir)) : media;
+
+  const fileList = copiedMedia.map((m) => {
+    const relativePath = workDir && m.path.startsWith(workDir)
+      ? m.path.slice(workDir.length).replace(/^[/\\]/, '')
+      : m.path;
+    const typeNames: Record<string, string> = { image: '图片', file: '文件', video: '视频' };
+    const sizeStr = m.size ? `${(m.size / 1024).toFixed(1)}KB` : '未知大小';
+    return `- ${m.fileName}\n  类型: ${typeNames[m.type] || '文件'}\n  大小: ${sizeStr}\n  路径: ${relativePath}`;
+  }).join('\n\n');
+
+  const userPrompt = prompt.trim() && !prompt.startsWith('[文件:') && !prompt.startsWith('[图片:') && !prompt.startsWith('[视频:')
+    ? `\n\n用户说：${prompt}`
+    : '';
+
+  return `已接收到用户通过微信发送的文件：
+
+${fileList}
+
+文件已保存到工作目录。请勿主动读取或处理这些文件，等待用户明确指示需要做什么。${userPrompt}`;
 }
 
 export function stripAnsi(str: string): string {

--- a/src/adapters/claude.ts
+++ b/src/adapters/claude.ts
@@ -1,8 +1,6 @@
 import { log } from '../utils/logger.js';
 import type { CLIAdapter, ExecOptions, ExecResult, AdapterCapabilities, IntermediateMessage } from './base.js';
-import { commandExists, spawnProc, setupAbort, setupTimeout, isSessionError } from './base.js';
-import type { DownloadedMedia } from '../utils/media.js';
-import { copyMediaToWorkDir } from '../utils/media.js';
+import { commandExists, spawnProc, setupAbort, setupTimeout, isSessionError, buildMediaPrompt, collectUtf8, writeStdin } from './base.js';
 
 function truncate(text: string, maxLen: number): string {
   return text.length > maxLen ? `${text.substring(0, maxLen)}...` : text;
@@ -197,32 +195,6 @@ function summarizeToolResult(toolName: string | undefined, content: unknown): st
 
   // Default: do not dump raw result excerpts to avoid noisy/low-value spam.
   return '';
-}
-
-function buildMediaPrompt(prompt: string, media?: DownloadedMedia[], workDir?: string): string {
-  if (!media || media.length === 0) return prompt;
-  
-  // 复制文件到工作目录
-  const copiedMedia = workDir ? media.map(m => copyMediaToWorkDir(m, workDir)) : media;
-  
-  const fileList = copiedMedia.map(m => {
-    const relativePath = workDir && m.path.startsWith(workDir) 
-      ? m.path.slice(workDir.length).replace(/^[\/\\]/, '')
-      : m.path;
-    const typeNames: Record<string, string> = { image: '图片', file: '文件', video: '视频' };
-    const sizeStr = m.size ? `${(m.size / 1024).toFixed(1)}KB` : '未知大小';
-    return `- ${m.fileName}\n  类型: ${typeNames[m.type] || '文件'}\n  大小: ${sizeStr}\n  路径: ${relativePath}`;
-  }).join('\n\n');
-  
-  const userPrompt = prompt.trim() && !prompt.startsWith('[文件:') && !prompt.startsWith('[图片:') && !prompt.startsWith('[视频:')
-    ? `\n\n用户说：${prompt}`
-    : '';
-  
-  return `已接收到用户通过微信发送的文件：
-
-${fileList}
-
-文件已保存到工作目录。请勿主动读取或处理这些文件，等待用户明确指示需要做什么。${userPrompt}`;
 }
 
 export class ClaudeAdapter implements CLIAdapter {
@@ -443,19 +415,17 @@ export class ClaudeAdapter implements CLIAdapter {
       });
 
       // 通过 stdin 传递提示词
-      proc.stdin!.write(prompt, 'utf8');
-      proc.stdin!.end();
+      writeStdin(proc, prompt);
 
       setupAbort(proc, opts.signal);
       const timer = setupTimeout(proc, opts.timeout);
-      let stdout = '', stderr = '';
-      proc.stdout!.on('data', (c: Buffer) => { stdout += c.toString(); });
-      proc.stderr!.on('data', (c: Buffer) => { stderr += c.toString(); });
+      const collected = collectUtf8(proc);
 
       proc.on('close', (code) => {
         if (timer) clearTimeout(timer);
         if (opts.signal?.aborted) { resolve({ text: '已取消', error: true }); return; }
 
+        const stdout = collected.stdout(), stderr = collected.stderr();
         let text = '';
         let thinking = '';
         let sessionId: string | undefined;

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -1,33 +1,6 @@
 import { log } from '../utils/logger.js';
 import type { CLIAdapter, ExecOptions, ExecResult, AdapterCapabilities } from './base.js';
-import { commandExists, spawnProc, setupAbort, setupTimeout, stripAnsi, isSessionError } from './base.js';
-import type { DownloadedMedia } from '../utils/media.js';
-import { copyMediaToWorkDir } from '../utils/media.js';
-
-function buildMediaPrompt(prompt: string, media?: DownloadedMedia[], workDir?: string): string {
-  if (!media || media.length === 0) return prompt;
-  
-  const copiedMedia = workDir ? media.map(m => copyMediaToWorkDir(m, workDir)) : media;
-  
-  const fileList = copiedMedia.map(m => {
-    const relativePath = workDir && m.path.startsWith(workDir) 
-      ? m.path.slice(workDir.length).replace(/^[\/\\]/, '')
-      : m.path;
-    const typeNames: Record<string, string> = { image: '图片', file: '文件', video: '视频' };
-    const sizeStr = m.size ? `${(m.size / 1024).toFixed(1)}KB` : '未知大小';
-    return `- ${m.fileName}\n  类型: ${typeNames[m.type] || '文件'}\n  大小: ${sizeStr}\n  路径: ${relativePath}`;
-  }).join('\n\n');
-  
-  const userPrompt = prompt.trim() && !prompt.startsWith('[文件:') && !prompt.startsWith('[图片:') && !prompt.startsWith('[视频:')
-    ? `\n\n用户说：${prompt}`
-    : '';
-  
-  return `已接收到用户通过微信发送的文件：
-
-${fileList}
-
-文件已保存到工作目录。请勿主动读取或处理这些文件，等待用户明确指示需要做什么。${userPrompt}`;
-}
+import { commandExists, spawnProc, setupAbort, setupTimeout, stripAnsi, isSessionError, buildMediaPrompt, collectUtf8, writeStdin } from './base.js';
 
 export class CodexAdapter implements CLIAdapter {
   readonly name = 'codex';
@@ -84,23 +57,21 @@ export class CodexAdapter implements CLIAdapter {
 
       log.debug(`[codex] mode=${settings.mode} sandbox=${settings.sandbox || 'yolo'} search=${settings.search}`);
       const proc = spawnProc(this.command, args, {
-        cwd: opts.workDir, stdio: ['pipe', 'pipe', 'pipe'], env: { ...process.env },
+        cwd: workDir, stdio: ['pipe', 'pipe', 'pipe'], env: { ...process.env },
       });
 
       // Pass prompt via stdin to avoid Windows cmd.exe Unicode encoding issues
       log.debug(`[codex] stdin: ${fullPrompt.substring(0, 200)}${fullPrompt.length > 200 ? '…' : ''}`);
-      proc.stdin!.write(fullPrompt, 'utf8');
-      proc.stdin!.end();
+      writeStdin(proc, fullPrompt);
 
       setupAbort(proc, opts.signal);
       const timer = setupTimeout(proc, opts.timeout);
-      let stdout = '', stderr = '';
-      proc.stdout!.on('data', (c: Buffer) => { stdout += c.toString(); });
-      proc.stderr!.on('data', (c: Buffer) => { stderr += c.toString(); });
+      const out = collectUtf8(proc);
 
       proc.on('close', (code) => {
         if (timer) clearTimeout(timer);
         if (opts.signal?.aborted) { resolve({ text: '已取消', error: true }); return; }
+        const stdout = out.stdout(), stderr = out.stderr();
         const text = stripAnsi(stdout.trim() || stderr.trim()) || `exit ${code}`;
         // Mark session exists so next call uses --last to resume
         resolve({ text, sessionId: code === 0 ? 'last' : undefined, error: code !== 0, sessionExpired: code !== 0 && !!hasSession && isSessionError(text) });

--- a/src/adapters/gemini.ts
+++ b/src/adapters/gemini.ts
@@ -1,33 +1,6 @@
 import { log } from '../utils/logger.js';
 import type { CLIAdapter, ExecOptions, ExecResult, AdapterCapabilities } from './base.js';
-import { commandExists, spawnProc, setupAbort, setupTimeout, stripAnsi, isSessionError } from './base.js';
-import type { DownloadedMedia } from '../utils/media.js';
-import { copyMediaToWorkDir } from '../utils/media.js';
-
-function buildMediaPrompt(prompt: string, media?: DownloadedMedia[], workDir?: string): string {
-  if (!media || media.length === 0) return prompt;
-  
-  const copiedMedia = workDir ? media.map(m => copyMediaToWorkDir(m, workDir)) : media;
-  
-  const fileList = copiedMedia.map(m => {
-    const relativePath = workDir && m.path.startsWith(workDir) 
-      ? m.path.slice(workDir.length).replace(/^[\/\\]/, '')
-      : m.path;
-    const typeNames: Record<string, string> = { image: '图片', file: '文件', video: '视频' };
-    const sizeStr = m.size ? `${(m.size / 1024).toFixed(1)}KB` : '未知大小';
-    return `- ${m.fileName}\n  类型: ${typeNames[m.type] || '文件'}\n  大小: ${sizeStr}\n  路径: ${relativePath}`;
-  }).join('\n\n');
-  
-  const userPrompt = prompt.trim() && !prompt.startsWith('[文件:') && !prompt.startsWith('[图片:') && !prompt.startsWith('[视频:')
-    ? `\n\n用户说：${prompt}`
-    : '';
-  
-  return `已接收到用户通过微信发送的文件：
-
-${fileList}
-
-文件已保存到工作目录。请勿主动读取或处理这些文件，等待用户明确指示需要做什么。${userPrompt}`;
-}
+import { commandExists, spawnProc, setupAbort, setupTimeout, stripAnsi, isSessionError, buildMediaPrompt, collectUtf8, writeStdin } from './base.js';
 
 export class GeminiAdapter implements CLIAdapter {
   readonly name = 'gemini';
@@ -78,18 +51,16 @@ export class GeminiAdapter implements CLIAdapter {
 
       // Write prompt to stdin
       log.debug(`[gemini] stdin: ${fullPrompt.substring(0, 200)}${fullPrompt.length > 200 ? '…' : ''}`);
-      proc.stdin!.write(fullPrompt, 'utf8');
-      proc.stdin!.end();
+      writeStdin(proc, fullPrompt);
 
       setupAbort(proc, opts.signal);
       const timer = setupTimeout(proc, opts.timeout);
-      let stdout = '', stderr = '';
-      proc.stdout!.on('data', (c: Buffer) => { stdout += c.toString(); });
-      proc.stderr!.on('data', (c: Buffer) => { stderr += c.toString(); });
+      const out = collectUtf8(proc);
 
       proc.on('close', (code) => {
         if (timer) clearTimeout(timer);
         if (opts.signal?.aborted) { resolve({ text: '已取消', error: true }); return; }
+        const stdout = out.stdout(), stderr = out.stderr();
         try {
           const r = JSON.parse(stdout);
           const isErr = !!r.error;

--- a/src/adapters/kimi.ts
+++ b/src/adapters/kimi.ts
@@ -1,33 +1,6 @@
 import { log } from '../utils/logger.js';
 import type { CLIAdapter, ExecOptions, ExecResult, AdapterCapabilities } from './base.js';
-import { commandExists, spawnProc, setupAbort, setupTimeout, stripAnsi } from './base.js';
-import type { DownloadedMedia } from '../utils/media.js';
-import { copyMediaToWorkDir } from '../utils/media.js';
-
-function buildMediaPrompt(prompt: string, media?: DownloadedMedia[], workDir?: string): string {
-  if (!media || media.length === 0) return prompt;
-  
-  const copiedMedia = workDir ? media.map(m => copyMediaToWorkDir(m, workDir)) : media;
-  
-  const fileList = copiedMedia.map(m => {
-    const relativePath = workDir && m.path.startsWith(workDir) 
-      ? m.path.slice(workDir.length).replace(/^[\/\\]/, '')
-      : m.path;
-    const typeNames: Record<string, string> = { image: '图片', file: '文件', video: '视频' };
-    const sizeStr = m.size ? `${(m.size / 1024).toFixed(1)}KB` : '未知大小';
-    return `- ${m.fileName}\n  类型: ${typeNames[m.type] || '文件'}\n  大小: ${sizeStr}\n  路径: ${relativePath}`;
-  }).join('\n\n');
-  
-  const userPrompt = prompt.trim() && !prompt.startsWith('[文件:') && !prompt.startsWith('[图片:') && !prompt.startsWith('[视频:')
-    ? `\n\n用户说：${prompt}`
-    : '';
-  
-  return `已接收到用户通过微信发送的文件：
-
-${fileList}
-
-文件已保存到工作目录。请勿主动读取或处理这些文件，等待用户明确指示需要做什么。${userPrompt}`;
-}
+import { commandExists, spawnProc, setupAbort, setupTimeout, stripAnsi, buildMediaPrompt, collectUtf8, writeStdin } from './base.js';
 
 export class KimiAdapter implements CLIAdapter {
   readonly name = 'kimi';
@@ -47,10 +20,11 @@ export class KimiAdapter implements CLIAdapter {
       const fullPrompt = buildMediaPrompt(prompt, opts.media, workDir);
       const args: string[] = [];
 
-      // ── Prompt ──
-      args.push('-p', fullPrompt);
-
       // ── Print mode (non-interactive, implies --yolo) ──
+      // The prompt is fed via stdin (below), NOT argv: passing free-form user text as a
+      // `-p <prompt>` argv element is a shell-injection vector on Windows where spawnProc
+      // runs under cmd.exe (shell:true), so a WeChat message with &, |, %VAR%, etc. would
+      // be interpreted by the shell. stdin avoids cmd.exe parsing entirely.
       args.push('--print');
 
       // ── Output format ──
@@ -95,8 +69,10 @@ export class KimiAdapter implements CLIAdapter {
       if (settings.verbose) args.push('--verbose');
 
       // ── System prompt (via config override) ──
+      // No hand-rolled quotes: spawn passes this as a single argv token, so quoting the
+      // value ourselves both breaks on values containing quotes and adds injection surface.
       if (settings.systemPrompt) {
-        args.push('--config', `agent.system_prompt_suffix="${settings.systemPrompt}"`);
+        args.push('--config', `agent.system_prompt_suffix=${settings.systemPrompt}`);
       }
 
       if (opts.extraArgs) args.push(...opts.extraArgs);
@@ -104,21 +80,22 @@ export class KimiAdapter implements CLIAdapter {
       log.debug(`[kimi] model=${settings.model || 'default'} thinking=${settings.thinking || false}`);
 
       const proc = spawnProc(this.command, args, {
-        cwd: settings.workDir || opts.workDir, stdio: ['ignore', 'pipe', 'pipe'], env: { ...process.env },
+        cwd: settings.workDir || opts.workDir, stdio: ['pipe', 'pipe', 'pipe'], env: { ...process.env },
       });
+
+      // Feed the prompt over stdin (see note above) instead of argv.
+      log.debug(`[kimi] stdin: ${fullPrompt.substring(0, 200)}${fullPrompt.length > 200 ? '…' : ''}`);
+      writeStdin(proc, fullPrompt);
 
       setupAbort(proc, opts.signal);
       const timer = setupTimeout(proc, opts.timeout);
-
-      let stdout = '';
-      let stderr = '';
-      proc.stdout!.on('data', (c: Buffer) => { stdout += c.toString(); });
-      proc.stderr!.on('data', (c: Buffer) => { stderr += c.toString(); });
+      const out = collectUtf8(proc);
 
       proc.on('close', (code) => {
         if (timer) clearTimeout(timer);
         if (opts.signal?.aborted) { resolve({ text: '已取消', error: true }); return; }
 
+        const stdout = out.stdout(), stderr = out.stderr();
         const output = stripAnsi(stdout.trim() || stderr.trim());
 
         // Try to extract session ID from stderr (kimi outputs session info there)

--- a/src/adapters/opencode.ts
+++ b/src/adapters/opencode.ts
@@ -1,8 +1,6 @@
 import { log } from '../utils/logger.js';
 import type { CLIAdapter, ExecOptions, ExecResult, AdapterCapabilities } from './base.js';
-import { commandExists, spawnProc, setupAbort, setupTimeout, stripAnsi } from './base.js';
-import type { DownloadedMedia } from '../utils/media.js';
-import { copyMediaToWorkDir } from '../utils/media.js';
+import { commandExists, spawnProc, setupAbort, setupTimeout, stripAnsi, buildMediaPrompt, collectUtf8, writeStdin } from './base.js';
 import { execSync } from 'node:child_process';
 
 const modelResolveCache = new Map<string, string>();
@@ -22,31 +20,6 @@ export function resolveBareModelFromList(model: string, availableModels: string[
 
   const preferred = matches.find((item) => /baiduqianfancodingplan/i.test(item));
   return preferred || raw;
-}
-
-function buildMediaPrompt(prompt: string, media?: DownloadedMedia[], workDir?: string): string {
-  if (!media || media.length === 0) return prompt;
-  
-  const copiedMedia = workDir ? media.map(m => copyMediaToWorkDir(m, workDir)) : media;
-  
-  const fileList = copiedMedia.map(m => {
-    const relativePath = workDir && m.path.startsWith(workDir) 
-      ? m.path.slice(workDir.length).replace(/^[\/\\]/, '')
-      : m.path;
-    const typeNames: Record<string, string> = { image: '图片', file: '文件', video: '视频' };
-    const sizeStr = m.size ? `${(m.size / 1024).toFixed(1)}KB` : '未知大小';
-    return `- ${m.fileName}\n  类型: ${typeNames[m.type] || '文件'}\n  大小: ${sizeStr}\n  路径: ${relativePath}`;
-  }).join('\n\n');
-  
-  const userPrompt = prompt.trim() && !prompt.startsWith('[文件:') && !prompt.startsWith('[图片:') && !prompt.startsWith('[视频:')
-    ? `\n\n用户说：${prompt}`
-    : '';
-  
-  return `已接收到用户通过微信发送的文件：
-
-${fileList}
-
-文件已保存到工作目录。请勿主动读取或处理这些文件，等待用户明确指示需要做什么。${userPrompt}`;
 }
 
 export class OpenCodeAdapter implements CLIAdapter {
@@ -129,20 +102,16 @@ private resolveModelArg(model: string, workDir?: string): string {
       });
 
       // 通过 stdin 传递提示词
-      proc.stdin!.write(fullPrompt, 'utf8');
-      proc.stdin!.end();
+      writeStdin(proc, fullPrompt);
 
       setupAbort(proc, opts.signal);
       const timer = setupTimeout(proc, opts.timeout);
-
-      let stdout = '';
-      let stderr = '';
-      proc.stdout!.on('data', (c: Buffer) => { stdout += c.toString(); });
-      proc.stderr!.on('data', (c: Buffer) => { stderr += c.toString(); });
+      const out = collectUtf8(proc);
 
       proc.on('close', (code) => {
         if (timer) clearTimeout(timer);
         if (opts.signal?.aborted) { resolve({ text: '已取消', error: true }); return; }
+        const stdout = out.stdout(), stderr = out.stderr();
 
         log.debug(`[opencode] stdout length: ${stdout.length}, first 500 chars: ${stdout.substring(0, 500)}`);
 

--- a/src/bridge/router.ts
+++ b/src/bridge/router.ts
@@ -50,6 +50,20 @@ export class Router {
     });
   }
 
+  /** Abort every in-flight CLI task and cancel pending questions — called on shutdown so
+   *  spawned children get a SIGTERM/taskkill instead of being orphaned. */
+  stop(): void {
+    const seen = new Set<AbortController>();
+    for (const task of this.active.values()) {
+      if (!seen.has(task.abort)) { seen.add(task.abort); task.abort.abort(); }
+    }
+    this.active.clear();
+    for (const pending of this.pendingQuestions.values()) {
+      clearTimeout(pending.timeout);
+    }
+    this.pendingQuestions.clear();
+  }
+
   private resolveToolFromRefText(refText: string): string | undefined {
     // Parse tool from footer: "— DisplayName | ..."
     const footerMatch = refText.match(/— ([^\|\n]+?)(?:\s*\||\s*$)/m);
@@ -463,10 +477,14 @@ const noTrailingSlash = unquoted.replace(/\/+$/, '');
         }
         return true;
 
-      case 'verbose': case 'v':
-        this.sessions.update(uid, { verbose: !settings.verbose });
-        await reply(`verbose(Kimi CLI) → ${!settings.verbose ? 'ON' : 'OFF'}`);
+      case 'verbose': case 'v': {
+        // Capture the new value first: update() mutates the live `settings` object,
+        // so reading settings.verbose after update() would report the opposite state.
+        const v = !settings.verbose;
+        this.sessions.update(uid, { verbose: v });
+        await reply(`verbose(Kimi CLI) → ${v ? 'ON' : 'OFF'}`);
         return true;
+      }
 
       // ═══════════════════════════════════════════
       // Codex
@@ -486,15 +504,19 @@ const noTrailingSlash = unquoted.replace(/\/+$/, '');
         return true;
       }
 
-      case 'search':
-        this.sessions.update(uid, { search: !settings.search });
-        await reply(`search → ${!settings.search ? 'ON' : 'OFF'}`);
+      case 'search': {
+        const v = !settings.search;
+        this.sessions.update(uid, { search: v });
+        await reply(`search → ${v ? 'ON' : 'OFF'}`);
         return true;
+      }
 
-      case 'ephemeral':
-        this.sessions.update(uid, { ephemeral: !settings.ephemeral });
-        await reply(`ephemeral → ${!settings.ephemeral ? 'ON' : 'OFF'}`);
+      case 'ephemeral': {
+        const v = !settings.ephemeral;
+        this.sessions.update(uid, { ephemeral: v });
+        await reply(`ephemeral → ${v ? 'ON' : 'OFF'}`);
         return true;
+      }
 
       case 'profile':
         if (!arg) { await reply(`当前: ${settings.profile || '无'}\n/profile <名称> 或 /profile reset`); return true; }
@@ -507,8 +529,9 @@ const noTrailingSlash = unquoted.replace(/\/+$/, '');
       // ═══════════════════════════════════════════
 
       case 'thinking': {
-        this.sessions.update(uid, { thinking: !settings.thinking });
-        await reply(`thinking → ${!settings.thinking ? 'ON (深度思考)' : 'OFF'}`);
+        const v = !settings.thinking;
+        this.sessions.update(uid, { thinking: v });
+        await reply(`thinking → ${v ? 'ON (深度思考)' : 'OFF'}`);
         return true;
       }
 
@@ -645,10 +668,12 @@ const noTrailingSlash = unquoted.replace(/\/+$/, '');
       // Claude 额外
       // ═══════════════════════════════════════════
 
-      case 'bare':
-        this.sessions.update(uid, { bare: !settings.bare } as any);
-        await reply(`bare → ${!(settings as any).bare ? 'ON (跳过配置加载)' : 'OFF'}`);
+      case 'bare': {
+        const v = !settings.bare;
+        this.sessions.update(uid, { bare: v } as any);
+        await reply(`bare → ${v ? 'ON (跳过配置加载)' : 'OFF'}`);
         return true;
+      }
 
       case 'adddir': case 'add-dir':
         if (!arg) { await reply(`当前: ${(settings as any).addDir || '无'}\n/adddir <路径>`); return true; }

--- a/src/bridge/session.ts
+++ b/src/bridge/session.ts
@@ -1,6 +1,6 @@
-import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
-import { getSessionsDir } from '../config.js';
+import { getSessionsDir, atomicWrite } from '../config.js';
 import { DEFAULT_SETTINGS, type UserSettings } from '../adapters/base.js';
 
 export class SessionManager {
@@ -61,7 +61,7 @@ export class SessionManager {
     const out: Record<string, UserSettings> = {};
     for (const [k, v] of this.data) out[k] = v;
     try {
-      writeFileSync(this.filePath(), JSON.stringify(out, null, 2), { mode: 0o600 });
+      atomicWrite(this.filePath(), JSON.stringify(out, null, 2));
     } catch { /* ignore */ }
   }
 }

--- a/src/cli/send.ts
+++ b/src/cli/send.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { generateWechatUin } from '../utils/crypto.js';
+import { fetchWithRetry } from '../utils/http.js';
 import { loadCredentials, loadContextTokens } from '../config.js';
 import type { Credentials } from '../ilink/types.js';
 
@@ -82,9 +83,12 @@ async function sendRawMessage(
   contextToken: string,
   text: string,
 ): Promise<void> {
-  const res = await fetch(
+  const res = await fetchWithRetry(
     `${credentials.baseUrl}/ilink/bot/sendmessage`,
     {
+      label: 'cli-send',
+      retries: 2,
+      timeoutMs: 30_000,
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,26 @@
-import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync, existsSync, renameSync, chmodSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { Credentials } from './ilink/types.js';
+
+/**
+ * Write a file atomically: write to a sibling temp file (same directory, so rename is a
+ * cheap inode swap on the same filesystem) then rename over the target. A crash mid-write
+ * can never leave a half-written config/credentials/sessions file that fails to parse.
+ * The mode is set on the temp file because rename replaces the inode (perms are not inherited).
+ */
+export function atomicWrite(filePath: string, data: string, mode = 0o600): void {
+  const tmp = `${filePath}.${process.pid}.tmp`;
+  writeFileSync(tmp, data, { mode });
+  // rename is atomic on the same filesystem; fall back to a direct write only if it fails
+  // (e.g. an exotic FS that disallows rename-over), accepting the small non-atomic window.
+  try {
+    renameSync(tmp, filePath);
+  } catch {
+    writeFileSync(filePath, data, { mode });
+    try { unlinkSync(tmp); } catch { /* best-effort: don't leave a stale .tmp orphan */ }
+  }
+}
 
 const DATA_DIR = join(homedir(), '.wx-ai-bridge');
 const CONFIG_FILE = join(DATA_DIR, 'config.json');
@@ -38,6 +57,12 @@ const DEFAULT_CONFIG: BridgeConfig = {
 export function ensureDataDir(): void {
   mkdirSync(DATA_DIR, { recursive: true, mode: 0o700 });
   mkdirSync(SESSIONS_DIR, { recursive: true, mode: 0o700 });
+  // mkdirSync's mode is ignored when the dir already exists (and on Windows); repair it so
+  // an already-present ~/.wx-ai-bridge (holding credentials) is not world-readable.
+  try {
+    chmodSync(DATA_DIR, 0o700);
+    chmodSync(SESSIONS_DIR, 0o700);
+  } catch { /* chmod is a no-op / unsupported on Windows; ignore */ }
 }
 
 export function loadConfig(): BridgeConfig {
@@ -53,7 +78,7 @@ export function loadConfig(): BridgeConfig {
 
 export function saveConfig(config: BridgeConfig): void {
   ensureDataDir();
-  writeFileSync(CONFIG_FILE, JSON.stringify(config, null, 2), { mode: 0o600 });
+  atomicWrite(CONFIG_FILE, JSON.stringify(config, null, 2));
 }
 
 export function loadCredentials(): Credentials | null {
@@ -69,12 +94,12 @@ export function loadCredentials(): Credentials | null {
 
 export function saveCredentials(creds: Credentials): void {
   ensureDataDir();
-  writeFileSync(CREDENTIALS_FILE, JSON.stringify(creds, null, 2), { mode: 0o600 });
+  atomicWrite(CREDENTIALS_FILE, JSON.stringify(creds, null, 2));
 }
 
 export function clearCredentials(): void {
   if (existsSync(CREDENTIALS_FILE)) {
-    writeFileSync(CREDENTIALS_FILE, '{}', { mode: 0o600 });
+    atomicWrite(CREDENTIALS_FILE, '{}');
   }
 }
 
@@ -89,16 +114,14 @@ export function loadPollCursor(): string {
 
 export function savePollCursor(cursor: string): void {
   ensureDataDir();
-  writeFileSync(POLL_CURSOR_FILE, cursor, { mode: 0o600 });
+  atomicWrite(POLL_CURSOR_FILE, cursor);
 }
 
 export function saveContextTokens(tokens: Map<string, string>): void {
   ensureDataDir();
   const obj: Record<string, string> = {};
   for (const [k, v] of tokens) obj[k] = v;
-  const tmp = CONTEXT_TOKENS_FILE + '.tmp';
-  writeFileSync(tmp, JSON.stringify(obj, null, 2), { mode: 0o600 });
-  renameSync(tmp, CONTEXT_TOKENS_FILE);
+  atomicWrite(CONTEXT_TOKENS_FILE, JSON.stringify(obj, null, 2));
 }
 
 export function loadContextTokens(): Map<string, string> {

--- a/src/ilink/auth.ts
+++ b/src/ilink/auth.ts
@@ -1,11 +1,15 @@
 import { log } from '../utils/logger.js';
+import { fetchWithRetry } from '../utils/http.js';
 import type { Credentials, QRCodeResponse, QRCodeStatusResponse } from './types.js';
 
 const DEFAULT_BASE_URL = 'https://ilinkai.weixin.qq.com';
 
 export async function getQRCode(): Promise<QRCodeResponse> {
-  const res = await fetch(
+  // This is the first network call on startup and the exact crash site of issue #18:
+  // a transient `read ECONNRESET` here used to take down the whole process. Retry hard.
+  const res = await fetchWithRetry(
     `${DEFAULT_BASE_URL}/ilink/bot/get_bot_qrcode?bot_type=3`,
+    { label: 'QR', retries: 4, retryOnHttpError: true, timeoutMs: 20_000 },
   );
   if (!res.ok) throw new Error(`获取二维码失败: HTTP ${res.status}`);
   return res.json() as Promise<QRCodeResponse>;
@@ -14,9 +18,10 @@ export async function getQRCode(): Promise<QRCodeResponse> {
 export async function pollQRCodeStatus(
   qrcode: string,
 ): Promise<QRCodeStatusResponse> {
-  const res = await fetch(
+  // Polled every 2s in a loop, so keep retries light — the loop itself is the outer retry.
+  const res = await fetchWithRetry(
     `${DEFAULT_BASE_URL}/ilink/bot/get_qrcode_status?qrcode=${encodeURIComponent(qrcode)}`,
-    { headers: { 'iLink-App-ClientVersion': '1' } },
+    { headers: { 'iLink-App-ClientVersion': '1' }, label: 'QR-status', retries: 1, timeoutMs: 15_000 },
   );
   if (!res.ok) throw new Error(`轮询二维码状态失败: HTTP ${res.status}`);
   return res.json() as Promise<QRCodeStatusResponse>;

--- a/src/ilink/client.ts
+++ b/src/ilink/client.ts
@@ -3,6 +3,7 @@ import { readFileSync, existsSync, statSync } from 'node:fs';
 import { basename } from 'node:path';
 import { generateWechatUin, encryptAesEcb, aesEcbPaddedSize, encodeMessageAesKey, md5 } from '../utils/crypto.js';
 import { log } from '../utils/logger.js';
+import { fetchWithRetry, describeNetworkError, isRetryableNetworkError } from '../utils/http.js';
 import { savePollCursor, loadPollCursor, saveContextTokens } from '../config.js';
 import { downloadImage, downloadFile, downloadVideo, type DownloadedMedia } from '../utils/media.js';
 import type {
@@ -52,6 +53,15 @@ export class ILinkClient {
   private rateLimitStates = new Map<string, UserRateLimitState>();
   private backoffMs = 1000;
   private abortController: AbortController | null = null;
+  private consecutiveFailures = 0;
+  private longPollTimeoutMs = HTTP_TIMEOUT_MS;
+  private reloginInFlight = false;
+  private onReloginNeeded?: () => Promise<Credentials | null>;
+  // Bounded de-dup of messages: the long-poll cursor can re-deliver a message
+  // (at-least-once), and re-running a CLI command twice is harmful. Keyed per-user
+  // (from_user_id:message_id) so we never collide across conversations.
+  private seenMsgIds = new Set<string>();
+  private seenMsgOrder: string[] = [];
 
   constructor(credentials: Credentials) {
     this.credentials = credentials;
@@ -60,6 +70,31 @@ export class ILinkClient {
 
   onMessage(handler: MessageHandler): void {
     this.handlers.push(handler);
+  }
+
+  /** Optional self-heal: invoked when the session expires (errcode -14/-13). Should
+   *  re-run the QR login, persist the new credentials, and return them — the poll loop
+   *  then swaps them in and continues instead of killing the whole process. */
+  setReloginHandler(handler: () => Promise<Credentials | null>): void {
+    this.onReloginNeeded = handler;
+  }
+
+  updateCredentials(credentials: Credentials): void {
+    this.credentials = credentials;
+  }
+
+  /** First-seen check for a (user, message) pair; records it (bounded) and returns false
+   *  on replay. Composite-keyed so two users never collide on the same numeric id. */
+  private isFreshMessage(userId: string, id: number): boolean {
+    const key = `${userId}:${id}`;
+    if (this.seenMsgIds.has(key)) return false;
+    this.seenMsgIds.add(key);
+    this.seenMsgOrder.push(key);
+    if (this.seenMsgOrder.length > 1000) {
+      const evict = this.seenMsgOrder.shift();
+      if (evict !== undefined) this.seenMsgIds.delete(evict);
+    }
+    return true;
   }
 
   private headers(): Record<string, string> {
@@ -96,6 +131,7 @@ export class ILinkClient {
       try {
         const msgs = await this.getUpdates();
         this.backoffMs = 1000;
+        this.consecutiveFailures = 0;
 
         for (const msg of msgs) {
           await this.processMessage(msg);
@@ -106,28 +142,79 @@ export class ILinkClient {
         const error = err as { name?: string; errcode?: number; message?: string };
 
         if (error.name === 'AbortError') {
-          continue; // normal timeout
+          continue; // normal long-poll timeout, not a failure
         }
 
         if (error.errcode === -14 || error.errcode === -13) {
-          log.error('会话已过期，需要重新登录 (删除 ~/.wx-ai-bridge/credentials.json 后重启)');
-          this.running = false;
-          return;
+          if (await this.handleSessionExpired()) continue;
+          // Keep running either way (never silently kill the process), but give advice that
+          // matches reality: only point at manual re-login when there is no relogin handler.
+          if (!this.onReloginNeeded) {
+            log.error('会话已过期。请删除 ~/.wx-ai-bridge/credentials.json 后重启以重新登录。');
+          } else {
+            log.warn('自动重新登录未成功，将在稍后重试…');
+          }
+          await sleep(30_000);
+          continue;
         }
 
-        log.error('轮询错误:', error.message || err);
-        await sleep(this.backoffMs);
+        this.consecutiveFailures += 1;
+        // Surface a loud, actionable diagnostic once the loop has been failing for a while
+        // (issue #18 class): a steady stream of generic '轮询错误' hides the real cause.
+        if (this.consecutiveFailures === 5 || this.consecutiveFailures % 20 === 0) {
+          if (isRetryableNetworkError(err)) {
+            log.error(`轮询持续失败 ${this.consecutiveFailures} 次:`);
+            log.error(describeNetworkError(err));
+          } else {
+            log.error(`轮询持续失败 ${this.consecutiveFailures} 次:`, error.message || err);
+          }
+        } else {
+          log.error('轮询错误:', error.message || err);
+        }
+
+        // Exponential backoff with full jitter, capped at 30s.
+        const jittered = Math.floor(this.backoffMs * (0.5 + Math.random() * 0.5));
+        await sleep(jittered);
         this.backoffMs = Math.min(this.backoffMs * 2, 30_000);
       }
     }
   }
 
+  /** Drive the optional relogin handler exactly once at a time. Returns true if the
+   *  session was refreshed (caller should continue the loop). */
+  private async handleSessionExpired(): Promise<boolean> {
+    if (!this.onReloginNeeded || this.reloginInFlight) return false;
+    this.reloginInFlight = true;
+    try {
+      log.warn('会话已过期，正在尝试重新登录…');
+      const creds = await this.onReloginNeeded();
+      if (creds) {
+        this.credentials = creds;
+        this.consecutiveFailures = 0;
+        this.backoffMs = 1000;
+        log.info('重新登录成功，继续运行');
+        return true;
+      }
+      return false;
+    } catch (err) {
+      log.error('自动重新登录失败:', (err as Error).message);
+      return false;
+    } finally {
+      this.reloginInFlight = false;
+    }
+  }
+
   private async getUpdates(): Promise<WeixinMessage[]> {
+    // Keep the manual long-poll deadline: when it fires it aborts the controller, which
+    // fetchWithRetry surfaces as an AbortError (NOT retried) so pollLoop treats it as a
+    // normal long-poll timeout. Genuine transient drops (ECONNRESET) within the window
+    // are retried by fetchWithRetry. The per-attempt timeout is a backstop set above the
+    // manual deadline so the manual abort always wins the race.
     this.abortController = new AbortController();
-    const timer = setTimeout(() => this.abortController?.abort(), HTTP_TIMEOUT_MS);
+    const timer = setTimeout(() => this.abortController?.abort(), this.longPollTimeoutMs);
 
     try {
-      const res = await fetch(
+      const res = await fetchWithRetry(
         `${this.credentials.baseUrl}/ilink/bot/getupdates`,
         {
           method: 'POST',
@@ -137,6 +224,10 @@ export class ILinkClient {
             base_info: this.baseInfo(),
           }),
           signal: this.abortController.signal,
+          label: 'getupdates',
+          retries: 2,
+          retryOnHttpError: true,
+          timeoutMs: this.longPollTimeoutMs + 15_000,
         },
       );
 
@@ -151,6 +242,13 @@ export class ILinkClient {
         );
         e.errcode = data.errcode;
         throw e;
+      }
+
+      // Honor the server-suggested long-poll window for the next round (clamped sanely),
+      // instead of always assuming the hardcoded 45s.
+      const serverMs = data.longpolling_timeout_ms;
+      if (typeof serverMs === 'number' && Number.isFinite(serverMs) && serverMs > 0) {
+        this.longPollTimeoutMs = Math.min(120_000, Math.max(10_000, serverMs + 5_000));
       }
 
       if (data.get_updates_buf) {
@@ -170,11 +268,17 @@ export class ILinkClient {
     // Only process user messages, skip bot echoes
     if (msg.message_type !== 1) return;
 
+    // Drop long-poll re-deliveries so a command is never executed twice (at-most-once).
+    if (!this.isFreshMessage(msg.from_user_id, msg.message_id)) {
+      log.debug(`[msg] 跳过重复消息 message_id=${msg.message_id}`);
+      return;
+    }
+
     // Cache context_token for this user
     this.contextTokens.set(msg.from_user_id, msg.context_token);
     saveContextTokens(this.contextTokens);
 
-    log.debug(`[msg] item_list=${JSON.stringify(msg.item_list)}`);
+    log.debug(`[msg] item_list=${JSON.stringify(redactSecrets(msg.item_list))}`);
     const { text, refText, mediaItems } = await parseMessage(msg);
     if (!text && !refText && mediaItems.length === 0) return;
 
@@ -324,7 +428,7 @@ export class ILinkClient {
     contextToken: string,
     itemList: MessageItem[],
   ): Promise<void> {
-    const res = await fetch(
+    const res = await fetchWithRetry(
       `${this.credentials.baseUrl}/ilink/bot/sendmessage`,
       {
         method: 'POST',
@@ -341,6 +445,9 @@ export class ILinkClient {
           },
           base_info: this.baseInfo(),
         }),
+        label: 'send',
+        retries: 2,
+        timeoutMs: 30_000,
       },
     );
 
@@ -473,7 +580,7 @@ export class ILinkClient {
     const aeskey = randomBytes(16);
 
     // Get upload URL from iLink
-    const uploadResp = await fetch(
+    const uploadResp = await fetchWithRetry(
       `${this.credentials.baseUrl}/ilink/bot/getuploadurl`,
       {
         method: 'POST',
@@ -489,6 +596,9 @@ export class ILinkClient {
           no_need_thumb: true,
           base_info: this.baseInfo(),
         }),
+        label: 'getuploadurl',
+        retries: 2,
+        timeoutMs: 30_000,
       },
     );
 
@@ -509,10 +619,13 @@ export class ILinkClient {
 
     log.debug(`[upload] Uploading to CDN: ${rawsize} bytes`);
 
-    const cdnResp = await fetch(cdnUrl, {
+    const cdnResp = await fetchWithRetry(cdnUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/octet-stream' },
       body: new Uint8Array(ciphertext),
+      label: 'cdn-upload',
+      retries: 2,
+      timeoutMs: 60_000, // large files need a longer per-attempt window
     });
 
     if (!cdnResp.ok) {
@@ -564,7 +677,7 @@ export class ILinkClient {
       return cached.ticket;
     }
 
-    const res = await fetch(
+    const res = await fetchWithRetry(
       `${this.credentials.baseUrl}/ilink/bot/getconfig`,
       {
         method: 'POST',
@@ -574,6 +687,9 @@ export class ILinkClient {
           context_token: contextToken,
           base_info: this.baseInfo(),
         }),
+        label: 'getconfig',
+        retries: 1,
+        timeoutMs: 15_000,
       },
     );
 
@@ -594,7 +710,8 @@ export class ILinkClient {
     ticket: string,
     status: 1 | 2,
   ): Promise<void> {
-    await fetch(`${this.credentials.baseUrl}/ilink/bot/sendtyping`, {
+    // Fire-and-forget heartbeat (every ~5s); a timeout prevents hung sockets from piling up.
+    await fetchWithRetry(`${this.credentials.baseUrl}/ilink/bot/sendtyping`, {
       method: 'POST',
       headers: this.headers(),
       body: JSON.stringify({
@@ -603,11 +720,34 @@ export class ILinkClient {
         status,
         base_info: this.baseInfo(),
       }),
+      label: 'sendtyping',
+      retries: 0,
+      timeoutMs: 10_000,
     });
   }
 }
 
 // ─── Helpers ───────────────────────────────────────────────
+
+const SECRET_KEYS = new Set([
+  'aes_key', 'aeskey', 'encrypt_query_param', 'full_url', 'url',
+]);
+
+/** Deep-clone a value while masking secret fields by name, so DEBUG logs never leak
+ *  media decryption keys / signed CDN URLs that could be replayed. */
+export function redactSecrets(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redactSecrets);
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      out[k] = SECRET_KEYS.has(k.toLowerCase())
+        ? (typeof v === 'string' && v.length > 0 ? '***' : v)
+        : redactSecrets(v);
+    }
+    return out;
+  }
+  return value;
+}
 
 async function parseMessage(msg: WeixinMessage): Promise<{ text: string; refText: string; mediaItems: DownloadedMedia[] }> {
   const parts: string[] = [];

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
   ensureDataDir,
 } from './config.js';
 import { log, setLogLevel, LogLevel } from './utils/logger.js';
+import { initProxyFromEnv } from './utils/http.js';
 
 async function main() {
   const subcommand = process.argv[2];
@@ -36,6 +37,9 @@ async function main() {
     setLogLevel(LogLevel.DEBUG);
   }
 
+  // Honor HTTPS_PROXY/HTTP_PROXY so users behind a proxy can reach WeChat (issue #18).
+  await initProxyFromEnv();
+
   // ─── 1. Detect CLI tools ─────────────────────────────
 
   log.info('检测已安装的 CLI 工具...');
@@ -57,31 +61,32 @@ async function main() {
 
   // ─── 2. WeChat login ─────────────────────────────────
 
-  let credentials = loadCredentials();
+  // QR display helper, defined once and reused for initial login AND session-expiry self-heal.
+  let qrGenerate: ((text: string, opts: { small: boolean }) => void) | null = null;
+  try {
+    const mod = await import('qrcode-terminal');
+    const qt = mod.default || mod;
+    qrGenerate = qt.generate?.bind(qt) ?? null;
+  } catch {
+    // fallback to URL display
+  }
+  const showQR = (qrContent: string) => {
+    if (qrGenerate) qrGenerate(qrContent, { small: true });
+    else log.info(`请用微信扫描二维码: ${qrContent}`);
+  };
 
+  let credentials = loadCredentials();
   if (!credentials) {
     log.info('需要登录微信 ClawBot...');
-
-    let qrGenerate: ((text: string, opts: { small: boolean }) => void) | null = null;
-    try {
-      const mod = await import('qrcode-terminal');
-      const qt = mod.default || mod;
-      qrGenerate = qt.generate?.bind(qt) ?? null;
-    } catch {
-      // fallback to URL display
-    }
-
-    credentials = await login((qrContent) => {
-      if (qrGenerate) {
-        qrGenerate(qrContent, { small: true });
-      } else {
-        log.info(`请用微信扫描二维码: ${qrContent}`);
-      }
-    });
-
+    credentials = await login(showQR);
     saveCredentials(credentials);
   } else {
     log.info('使用已保存的登录凭据');
+  }
+
+  if (config.allowedUsers.length === 0) {
+    log.warn('⚠️ allowedUsers 为空：任何能私聊机器人的微信好友都可运行 CLI（拥有完整权限）。');
+    log.warn('   如需限制，请在 ~/.wx-ai-bridge/config.json 设置 allowedUsers: ["<你的 ilink_user_id>"]');
   }
 
   // ─── 3. Start bridge ─────────────────────────────────
@@ -89,6 +94,13 @@ async function main() {
   const ilink = new ILinkClient(credentials);
   const sessions = new SessionManager();
   const router = new Router(ilink, registry, sessions, config);
+
+  // Self-heal on session expiry (errcode -14/-13): re-run QR login instead of crashing.
+  ilink.setReloginHandler(async () => {
+    const creds = await login(showQR);
+    saveCredentials(creds);
+    return creds;
+  });
 
   router.start();
   ilink.start();
@@ -100,17 +112,45 @@ async function main() {
 
   // ─── Graceful shutdown ────────────────────────────────
 
-  const shutdown = () => {
-    log.info('正在关闭...');
-    ilink.stop();
-    process.exit(0);
+  let shuttingDown = false;
+  const shutdown = (signal: string) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    log.info(`收到 ${signal}，正在关闭...`);
+    try { router.stop(); } catch { /* ignore */ }
+    try { ilink.stop(); } catch { /* ignore */ }
+    // Give in-flight aborts (child SIGTERM/taskkill) a brief moment, then exit.
+    setTimeout(() => process.exit(0), 300);
   };
 
-  process.on('SIGINT', shutdown);
-  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', () => shutdown('SIGINT'));
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+
+  // An unhandled *rejection* is usually a stray promise and safe to log-and-continue.
+  process.on('unhandledRejection', (reason) => {
+    log.error('未处理的 Promise 拒绝:', reason);
+  });
+  // An uncaught *exception* leaves the runtime in an undefined state (Node docs), so treat
+  // it as fatal: clean up and exit non-zero, letting a supervisor restart a fresh process.
+  process.on('uncaughtException', (err) => {
+    log.error('未捕获的异常 (即将退出):', err);
+    if (!shuttingDown) {
+      shuttingDown = true;
+      try { router.stop(); } catch { /* ignore */ }
+      try { ilink.stop(); } catch { /* ignore */ }
+    }
+    setTimeout(() => process.exit(1), 200);
+  });
 }
 
-main().catch((err) => {
-  log.error('启动失败:', err);
+main().catch(async (err) => {
+  const { isRetryableNetworkError, describeNetworkError } = await import('./utils/http.js');
+  if (isRetryableNetworkError(err) || /ECONNRESET|fetch failed|网络请求/.test(String(err?.message))) {
+    log.error('启动失败 (网络问题):');
+    log.error(describeNetworkError(err));
+    log.error('微信接口: https://ilinkai.weixin.qq.com — 确认本机可访问该地址后重试。');
+  } else {
+    log.error('启动失败:', err);
+  }
   process.exit(1);
 });

--- a/src/utils/http.ts
+++ b/src/utils/http.ts
@@ -1,0 +1,271 @@
+import { log } from './logger.js';
+
+// ─── Resilient fetch ────────────────────────────────────────
+//
+// issue #18 的根因：对 ilinkai.weixin.qq.com 的请求是裸 fetch，没有超时、
+// 没有重试。微信服务器在 TLS 握手/读取阶段偶发 `read ECONNRESET`（常见于代理、
+// IPv6、弱网、被中间设备重置），裸 fetch 直接把 TypeError 抛到 main()，启动即崩。
+// 这里提供一个统一的带「超时 + 指数退避抖动重试 + 可读诊断」的 fetch 包装，
+// 所有出网调用都走它，瞬时网络抖动会被自动重试吞掉，彻底失败时给出可操作的提示。
+
+/** Node/undici error codes that indicate a *transient* network failure worth retrying. */
+const RETRYABLE_CODES = new Set([
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ECONNREFUSED',
+  'ECONNABORTED',
+  'EAI_AGAIN',
+  'EPIPE',
+  'ENETUNREACH',
+  'EHOSTUNREACH',
+  'ENETDOWN',
+  'ENOTFOUND', // transient DNS hiccup; safe to retry a couple times
+  'UND_ERR_CONNECT_TIMEOUT',
+  'UND_ERR_HEADERS_TIMEOUT',
+  'UND_ERR_BODY_TIMEOUT',
+  'UND_ERR_SOCKET',
+]);
+
+// Only fragments that *specifically* indicate a transient drop. Deliberately NOT
+// 'fetch failed' — that is Node's generic wrapper for every network failure, so the
+// real signal is the underlying `cause.code` (checked above), not the wrapper text.
+const RETRYABLE_MESSAGE_FRAGMENTS = [
+  'socket hang up',
+  'terminated', // undici: connection closed mid-body
+];
+
+export interface FetchRetryOptions extends RequestInit {
+  /** Per-attempt timeout in ms. Default 30s. */
+  timeoutMs?: number;
+  /** Additional attempts after the first (total attempts = retries + 1). Default 3. */
+  retries?: number;
+  /** Base backoff in ms (grows exponentially with jitter). Default 500ms. */
+  retryDelayMs?: number;
+  /** Upper bound on a single backoff delay. Default 8s. */
+  maxRetryDelayMs?: number;
+  /** Retry on HTTP 429 / 5xx as well as on network errors. Default false (POSTs are not idempotent). */
+  retryOnHttpError?: boolean;
+  /** Short label for log lines, e.g. "QR" or "getupdates". */
+  label?: string;
+}
+
+/** Pull a low-level error code out of a fetch failure by walking the WHOLE cause chain.
+ *  Node wraps the real code one level deep (TypeError 'fetch failed' → cause.code), and
+ *  fetchWithRetry itself re-wraps once more on exhaustion, so the code can sit at
+ *  err.cause.cause.code — a single-level lookup would miss it and silently mis-classify
+ *  the exact issue #18 ECONNRESET as non-retryable. */
+function errorCode(err: unknown): string | undefined {
+  let cur = err as { code?: unknown; cause?: unknown } | undefined;
+  for (let depth = 0; cur && typeof cur === 'object' && depth < 6; depth++) {
+    if (typeof cur.code === 'string') return cur.code;
+    cur = cur.cause as typeof cur;
+  }
+  return undefined;
+}
+
+/** Is this thrown error a transient network failure that a retry might fix? */
+export function isRetryableNetworkError(err: unknown): boolean {
+  const code = errorCode(err);
+  if (code && RETRYABLE_CODES.has(code)) return true;
+
+  const name = (err as { name?: string })?.name;
+  // AbortSignal.timeout() rejects with a DOMException named 'TimeoutError'.
+  if (name === 'TimeoutError') return true;
+
+  const msg = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  return RETRYABLE_MESSAGE_FRAGMENTS.some((frag) => msg.includes(frag));
+}
+
+/** Walk to the deepest cause's message so the "原始错误" line shows the real low-level
+ *  failure ('read ECONNRESET') rather than a re-wrapped friendly string. */
+function rootErrorMessage(err: unknown): string {
+  let cur = err as { message?: unknown; cause?: unknown } | undefined;
+  let msg = err instanceof Error ? err.message : String(err);
+  for (let depth = 0; cur && typeof cur === 'object' && cur.cause && depth < 6; depth++) {
+    cur = cur.cause as typeof cur;
+    if (cur && typeof cur === 'object' && typeof cur.message === 'string' && cur.message) {
+      msg = cur.message;
+    }
+  }
+  return msg;
+}
+
+/** Turn a low-level network failure into an actionable, human-readable hint. */
+export function describeNetworkError(err: unknown): string {
+  const code = errorCode(err) || (err as { name?: string })?.name || 'UNKNOWN';
+  const base = rootErrorMessage(err);
+  const hints: Record<string, string> = {
+    ECONNRESET: '连接被重置 (ECONNRESET)。常见原因：代理/VPN、网络不稳定，或被中间设备拦截。可尝试：① 关闭或更换代理/VPN；② 设置 HTTPS_PROXY 环境变量走代理；③ 稍后重试。',
+    ETIMEDOUT: '连接超时 (ETIMEDOUT)。请检查网络连通性，或为出网设置 HTTPS_PROXY 代理。',
+    UND_ERR_CONNECT_TIMEOUT: '连接超时。请检查网络或代理设置 (HTTPS_PROXY)。',
+    ENOTFOUND: 'DNS 解析失败 (ENOTFOUND)。请检查网络/DNS，或确认能访问 ilinkai.weixin.qq.com。',
+    EAI_AGAIN: 'DNS 暂时不可用 (EAI_AGAIN)。请检查网络/DNS 设置。',
+    ECONNREFUSED: '连接被拒绝 (ECONNREFUSED)。目标端口不可达，检查代理或网络策略。',
+    TimeoutError: '请求超时。网络较慢或被阻断，可设置 HTTPS_PROXY 代理后重试。',
+  };
+  const hint = hints[code];
+  return hint ? `${hint}\n(原始错误: ${base})` : `网络请求失败 (${code}): ${base}`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/** Backoff with full jitter, capped. */
+function backoffDelay(attempt: number, base: number, max: number): number {
+  const exp = Math.min(max, base * 2 ** attempt);
+  return Math.floor(exp * (0.5 + Math.random() * 0.5));
+}
+
+/** Wrap a failed-fetch error with a friendly message while preserving the original as
+ *  `cause` AND surfacing the low-level code at depth 0, so downstream classifiers work
+ *  even though we re-wrap. */
+function wrapNetworkError(err: unknown): Error {
+  const wrapped = new Error(describeNetworkError(err), { cause: err });
+  const code = errorCode(err);
+  if (code) (wrapped as { code?: string }).code = code;
+  return wrapped;
+}
+
+/** Combine an external abort signal with a per-attempt timeout. Uses AbortSignal.any when
+ *  available (Node 20.3+/19.7+) and falls back to manual forwarding on older runtimes so
+ *  the bridge still works on the declared minimum Node (>=18). */
+function combineSignals(external: AbortSignal | undefined | null, timeout: AbortSignal): AbortSignal {
+  if (!external) return timeout;
+  const anyFn = (AbortSignal as { any?: (s: AbortSignal[]) => AbortSignal }).any;
+  if (typeof anyFn === 'function') return anyFn([external, timeout]);
+  const controller = new AbortController();
+  const forward = (s: AbortSignal) => { if (!controller.signal.aborted) controller.abort(s.reason); };
+  for (const s of [external, timeout]) {
+    if (s.aborted) { controller.abort(s.reason); break; }
+    s.addEventListener('abort', () => forward(s), { once: true });
+  }
+  return controller.signal;
+}
+
+/**
+ * fetch() with per-attempt timeout, transient-error retry (exponential backoff + jitter),
+ * cooperative external abort, and actionable diagnostics. Drop-in replacement for fetch().
+ */
+export async function fetchWithRetry(
+  url: string,
+  options: FetchRetryOptions = {},
+): Promise<Response> {
+  const {
+    timeoutMs = 30_000,
+    retries = 3,
+    retryDelayMs = 500,
+    maxRetryDelayMs = 8_000,
+    retryOnHttpError = false,
+    label,
+    signal: externalSignal,
+    ...init
+  } = options;
+
+  const tag = label ? `[http:${label}]` : '[http]';
+  let lastErr: unknown;
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    // Respect a caller-driven abort (shutdown, /cancel) before spending another attempt.
+    if (externalSignal?.aborted) {
+      throw externalSignal.reason instanceof Error
+        ? externalSignal.reason
+        : new DOMException('Aborted', 'AbortError');
+    }
+
+    const timeoutSignal = AbortSignal.timeout(timeoutMs);
+    const signal = combineSignals(externalSignal, timeoutSignal);
+
+    try {
+      const res = await fetch(url, { ...init, signal });
+
+      // Optionally retry server-side hiccups for idempotent calls.
+      if (retryOnHttpError && (res.status === 429 || res.status >= 500) && attempt < retries) {
+        const retryAfter = Number(res.headers.get('retry-after'));
+        const delay = Number.isFinite(retryAfter) && retryAfter > 0
+          ? Math.min(maxRetryDelayMs, retryAfter * 1000)
+          : backoffDelay(attempt, retryDelayMs, maxRetryDelayMs);
+        log.warn(`${tag} HTTP ${res.status}，${delay}ms 后重试 (${attempt + 1}/${retries})`);
+        await sleep(delay);
+        continue;
+      }
+
+      return res;
+    } catch (err) {
+      lastErr = err;
+
+      // An external abort (not our timeout) is intentional — never retry it.
+      if (externalSignal?.aborted) {
+        throw externalSignal.reason instanceof Error
+          ? externalSignal.reason
+          : new DOMException('Aborted', 'AbortError');
+      }
+
+      const retryable = isRetryableNetworkError(err);
+      if (!retryable || attempt === retries) {
+        // Out of attempts (or non-retryable): surface a clear, actionable error.
+        if (retryable) {
+          log.warn(`${tag} 已重试 ${retries} 次仍失败`);
+        }
+        throw wrapNetworkError(err);
+      }
+
+      const delay = backoffDelay(attempt, retryDelayMs, maxRetryDelayMs);
+      const code = errorCode(err) || (err as { name?: string })?.name || 'error';
+      log.warn(`${tag} ${code}，${delay}ms 后重试 (${attempt + 1}/${retries})`);
+      await sleep(delay);
+    }
+  }
+
+  // Unreachable, but keeps the type checker happy.
+  throw wrapNetworkError(lastErr);
+}
+
+// ─── Proxy support (opt-in, lazy) ───────────────────────────
+//
+// Node 的全局 fetch 默认不走 HTTP(S)_PROXY 环境变量。很多大陆用户需要代理才能稳定
+// 访问微信接口。若检测到代理环境变量，尝试用 undici 的 ProxyAgent 设置全局 dispatcher。
+// undici 是可选依赖：未安装时给出一次性提示而不是崩溃。
+
+let proxyInitialized = false;
+
+export async function initProxyFromEnv(): Promise<void> {
+  if (proxyInitialized) return;
+  proxyInitialized = true;
+
+  const proxyUrl =
+    process.env.HTTPS_PROXY ||
+    process.env.https_proxy ||
+    process.env.HTTP_PROXY ||
+    process.env.http_proxy ||
+    process.env.ALL_PROXY ||
+    process.env.all_proxy;
+
+  if (!proxyUrl) return;
+
+  try {
+    // Non-literal specifier: undici is an *optional* dependency, so we must not let
+    // the type checker hard-require it. Resolved at runtime only when a proxy is set.
+    const specifier = 'undici';
+    const undici = (await import(specifier)) as {
+      ProxyAgent: new (url: string) => unknown;
+      setGlobalDispatcher: (d: unknown) => void;
+    };
+    undici.setGlobalDispatcher(new undici.ProxyAgent(proxyUrl));
+    log.info(`已启用代理: ${redactProxy(proxyUrl)}`);
+  } catch {
+    log.warn(
+      `检测到代理环境变量但未安装 undici，代理未生效。如需通过代理访问微信，请运行: npm i undici`,
+    );
+  }
+}
+
+function redactProxy(url: string): string {
+  try {
+    const u = new URL(url);
+    if (u.password) u.password = '***';
+    return u.toString();
+  } catch {
+    return url;
+  }
+}

--- a/src/utils/media.ts
+++ b/src/utils/media.ts
@@ -3,6 +3,7 @@ import { join, basename } from 'node:path';
 import { homedir } from 'node:os';
 import { createDecipheriv } from 'node:crypto';
 import { log } from './logger.js';
+import { fetchWithRetry } from './http.js';
 import type { CDNMedia, ImageItem, FileItem, VideoItem } from '../ilink/types.js';
 import { parseAesKey } from '../utils/crypto.js';
 
@@ -53,12 +54,16 @@ export async function downloadMedia(
   
   log.debug(`[media] Downloading from: ${url.substring(0, 100)}...`);
   
-  const response = await fetch(url, {
+  const response = await fetchWithRetry(url, {
     headers: {
       'User-Agent': 'MicroMessenger/6.0',
     },
+    label: 'media-download',
+    retries: 3,
+    retryOnHttpError: true, // downloads are idempotent GETs
+    timeoutMs: 60_000,
   });
-  
+
   if (!response.ok) {
     const body = await response.text().catch(() => '');
     log.error(`[media] HTTP ${response.status}: ${body.substring(0, 200)}`);
@@ -90,9 +95,10 @@ export async function downloadMedia(
     log.warn(`[media] No aes_key and unrecognized format, saving raw bytes (file may be unviewable)`);
   }
   
-  const fileName = options.fileName || generateFileName(options.type);
+  // options.fileName may come straight from an untrusted WeChat file_item.file_name.
+  const fileName = safeFileName(options.fileName, options.type);
   const filePath = join(mediaDir, fileName);
-  
+
   writeFileSync(filePath, data);
   
   log.info(`[media] Saved: ${filePath} (${data.length} bytes)`);
@@ -113,8 +119,9 @@ export async function downloadImage(item: ImageItem, workDir?: string): Promise<
   if (item.url) {
     log.debug(`[media] Using direct URL: ${item.url}`);
     try {
-      const response = await fetch(item.url, {
+      const response = await fetchWithRetry(item.url, {
         headers: { 'User-Agent': 'MicroMessenger/6.0' },
+        label: 'image-url', retries: 2, retryOnHttpError: true, timeoutMs: 60_000,
       });
       if (response.ok) {
         const fileName = extractFileNameFromUrl(item.url);
@@ -211,16 +218,37 @@ function detectFileFormat(data: Buffer): string | null {
 }
 
 function generateFileName(type: 'image' | 'file' | 'video'): string {
-  const timestamp = Date.now();
+  // Date.now() alone collides for files that arrive in the same millisecond; add entropy.
+  const stamp = `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
   const ext = type === 'image' ? 'jpg' : type === 'video' ? 'mp4' : 'bin';
-  return `${type}_${timestamp}.${ext}`;
+  return `${type}_${stamp}.${ext}`;
+}
+
+/**
+ * Sanitize an untrusted file name (a WeChat sender controls file_item.file_name and
+ * the image URL path) so it can never escape the media directory or smuggle in path
+ * separators / control chars. Falls back to a generated name when nothing safe remains.
+ */
+export function safeFileName(name: string | undefined, type: 'image' | 'file' | 'video'): string {
+  if (!name) return generateFileName(type);
+  // Normalize Windows separators first so basename() strips them even on POSIX,
+  // then drop any directory components ("../../etc/passwd" -> "passwd").
+  let base = basename(name.replace(/\\/g, '/'));
+  // Remove control chars and characters illegal in file names across platforms.
+  base = base.replace(/[\x00-\x1f<>:"/\\|?*]/g, '_').trim();
+  // Strip leading dots so "..", ".ssh", ".env" cannot be produced.
+  base = base.replace(/^\.+/, '');
+  if (!base) return generateFileName(type);
+  // Cap absurdly long names (filesystem limits) while keeping the extension.
+  if (base.length > 200) base = base.slice(base.length - 200);
+  return base;
 }
 
 function extractFileNameFromUrl(url: string): string {
   try {
     const parsed = new URL(url);
     const pathParts = parsed.pathname.split('/');
-    return pathParts[pathParts.length - 1] || generateFileName('image');
+    return safeFileName(pathParts[pathParts.length - 1], 'image');
   } catch {
     return generateFileName('image');
   }

--- a/test/base-helpers.test.ts
+++ b/test/base-helpers.test.ts
@@ -1,0 +1,98 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { PassThrough } from 'node:stream';
+import { spawn } from 'node:child_process';
+
+import { collectUtf8, writeStdin, buildMediaPrompt, killProc } from '../src/adapters/base.js';
+import type { DownloadedMedia } from '../src/utils/media.js';
+
+// ─── collectUtf8: multibyte UTF-8 must survive chunk boundaries ──────────────
+
+test('collectUtf8: a Chinese character split across two data chunks is not corrupted', async () => {
+  const proc: any = { stdout: new PassThrough(), stderr: new PassThrough() };
+  const out = collectUtf8(proc);
+
+  // "你好" = e4 bd a0 e5 a5 bd. Split mid-character (after the first 2 bytes of 你).
+  const full = Buffer.from('你好世界', 'utf8');
+  const mid = 2; // splits the first multibyte char
+  proc.stdout.write(full.subarray(0, mid));
+  proc.stdout.write(full.subarray(mid));
+  proc.stdout.end();
+
+  await new Promise((r) => proc.stdout.on('end', r));
+
+  const text = out.stdout();
+  assert.equal(text, '你好世界');
+  assert.ok(!text.includes('�'), 'no replacement character');
+});
+
+test('collectUtf8: stderr is collected independently', async () => {
+  const proc: any = { stdout: new PassThrough(), stderr: new PassThrough() };
+  const out = collectUtf8(proc);
+  proc.stderr.write(Buffer.from('错误', 'utf8'));
+  proc.stderr.end();
+  proc.stdout.end();
+  await new Promise((r) => proc.stderr.on('end', r));
+  assert.equal(out.stderr(), '错误');
+  assert.equal(out.stdout(), '');
+});
+
+// ─── writeStdin: a benign EPIPE must not throw / crash ───────────────────────
+
+test('writeStdin: swallows an EPIPE error on the stdin stream', () => {
+  const stdin = new PassThrough();
+  const proc: any = { stdin };
+  // Should not throw even though we immediately make the stream emit an error.
+  assert.doesNotThrow(() => {
+    writeStdin(proc, 'hello');
+    stdin.emit('error', Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }));
+  });
+});
+
+test('writeStdin: writes the data and ends the stream', async () => {
+  const stdin = new PassThrough();
+  const proc: any = { stdin };
+  const chunks: Buffer[] = [];
+  stdin.on('data', (c) => chunks.push(Buffer.from(c)));
+  const ended = new Promise((r) => stdin.on('end', r));
+  writeStdin(proc, '你好 prompt');
+  stdin.resume();
+  await ended;
+  assert.equal(Buffer.concat(chunks).toString('utf8'), '你好 prompt');
+});
+
+test('writeStdin: no stdin (null) is a safe no-op', () => {
+  assert.doesNotThrow(() => writeStdin({ stdin: null } as any, 'x'));
+});
+
+// ─── buildMediaPrompt: centralized formatter ─────────────────────────────────
+
+test('buildMediaPrompt: returns the prompt unchanged when there is no media', () => {
+  assert.equal(buildMediaPrompt('hi', undefined), 'hi');
+  assert.equal(buildMediaPrompt('hi', []), 'hi');
+});
+
+test('buildMediaPrompt: lists files and appends the user prompt', () => {
+  const media: DownloadedMedia[] = [
+    { type: 'image', path: '/tmp/x/photo.jpg', fileName: 'photo.jpg', size: 2048 },
+  ];
+  const out = buildMediaPrompt('看看这张图', media); // no workDir → no copy
+  assert.match(out, /photo\.jpg/);
+  assert.match(out, /类型: 图片/);
+  assert.match(out, /用户说：看看这张图/);
+});
+
+// ─── killProc: guards ────────────────────────────────────────────────────────
+
+test('killProc: a process that already exited is a no-op', () => {
+  assert.doesNotThrow(() => killProc({ killed: false, exitCode: 0, pid: 1 } as any));
+  assert.doesNotThrow(() => killProc({ killed: true, exitCode: null, pid: 1 } as any));
+});
+
+test('killProc: actually terminates a live child (POSIX)', { skip: process.platform === 'win32' }, async () => {
+  const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 60000)']);
+  const exited = new Promise<number | null>((r) => child.on('exit', (code, signal) => r(signal ? -1 : code)));
+  killProc(child);
+  const result = await exited;
+  assert.equal(result, -1, 'child was killed by signal');
+});

--- a/test/client-internals.test.ts
+++ b/test/client-internals.test.ts
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { redactSecrets, ILinkClient } from '../src/ilink/client.js';
+import type { Credentials } from '../src/ilink/types.js';
+
+// ─── redactSecrets: never leak decryption keys / signed URLs into logs ───────
+
+test('redactSecrets: masks aes_key / encrypt_query_param / full_url / url', () => {
+  const input = {
+    type: 2,
+    image_item: {
+      media: {
+        aes_key: 'VERYSECRETKEY==',
+        encrypt_query_param: 'sig=abc&t=1',
+        full_url: 'https://cdn/x?token=zzz',
+        encrypt_type: 1,
+      },
+    },
+  };
+  const out = redactSecrets(input) as any;
+  assert.equal(out.image_item.media.aes_key, '***');
+  assert.equal(out.image_item.media.encrypt_query_param, '***');
+  assert.equal(out.image_item.media.full_url, '***');
+  assert.equal(out.image_item.media.encrypt_type, 1, 'non-secret fields preserved');
+});
+
+test('redactSecrets: recurses through arrays and preserves structure', () => {
+  const input = [{ url: 'http://a' }, { text_item: { text: 'hello' } }];
+  const out = redactSecrets(input) as any[];
+  assert.equal(out[0].url, '***');
+  assert.equal(out[1].text_item.text, 'hello');
+});
+
+test('redactSecrets: leaves empty/missing secret values untouched', () => {
+  const out = redactSecrets({ aes_key: '' }) as any;
+  assert.equal(out.aes_key, ''); // nothing to redact
+});
+
+test('redactSecrets: is case-insensitive on key names', () => {
+  const out = redactSecrets({ AES_KEY: 'x', Full_Url: 'http://y' }) as any;
+  assert.equal(out.AES_KEY, '***');
+  assert.equal(out.Full_Url, '***');
+});
+
+// ─── isFreshMessage: long-poll re-delivery de-dup ────────────────────────────
+
+const DUMMY_CREDS: Credentials = {
+  botToken: 't', baseUrl: 'https://example.com', ilinkBotId: 'b', ilinkUserId: 'u',
+};
+
+test('isFreshMessage: first sighting true, replay false', () => {
+  const client = new ILinkClient(DUMMY_CREDS) as any;
+  assert.equal(client.isFreshMessage('userA', 1001), true);
+  assert.equal(client.isFreshMessage('userA', 1001), false);
+  assert.equal(client.isFreshMessage('userA', 1002), true);
+});
+
+test('isFreshMessage: same numeric id from different users does NOT collide', () => {
+  const client = new ILinkClient(DUMMY_CREDS) as any;
+  assert.equal(client.isFreshMessage('userA', 5), true);
+  assert.equal(client.isFreshMessage('userB', 5), true, "userB's message 5 is not a dup of userA's");
+  assert.equal(client.isFreshMessage('userA', 5), false);
+});
+
+test('isFreshMessage: evicts oldest beyond the 1000-entry cap but keeps recent ones', () => {
+  const client = new ILinkClient(DUMMY_CREDS) as any;
+  for (let i = 0; i < 1000; i++) assert.equal(client.isFreshMessage('u', i), true);
+  // Insert one more → the oldest key (u:0) is evicted.
+  assert.equal(client.isFreshMessage('u', 1000), true);
+  assert.equal(client.isFreshMessage('u', 0), true, 'evicted key is treated as fresh again');
+  // A recently-seen key is still remembered.
+  assert.equal(client.isFreshMessage('u', 999), false);
+});

--- a/test/config-atomic.test.ts
+++ b/test/config-atomic.test.ts
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { atomicWrite } from '../src/config.js';
+
+function withTmpDir(fn: (dir: string) => void): void {
+  const dir = mkdtempSync(join(tmpdir(), 'wxcfg-'));
+  try {
+    fn(dir);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('atomicWrite: writes content that reads back exactly', () => {
+  withTmpDir((dir) => {
+    const f = join(dir, 'config.json');
+    atomicWrite(f, '{"a":1}');
+    assert.equal(readFileSync(f, 'utf8'), '{"a":1}');
+  });
+});
+
+test('atomicWrite: leaves no .tmp turd behind', () => {
+  withTmpDir((dir) => {
+    const f = join(dir, 'credentials.json');
+    atomicWrite(f, 'secret');
+    const leftovers = readdirSync(dir).filter((n) => n.includes('.tmp'));
+    assert.deepEqual(leftovers, []);
+  });
+});
+
+test('atomicWrite: overwrites an existing file (no append/corruption)', () => {
+  withTmpDir((dir) => {
+    const f = join(dir, 'cursor.txt');
+    writeFileSync(f, 'OLD-LONGER-CONTENT');
+    atomicWrite(f, 'new');
+    assert.equal(readFileSync(f, 'utf8'), 'new');
+  });
+});
+
+test('atomicWrite: applies 0600 mode on POSIX', { skip: process.platform === 'win32' }, () => {
+  withTmpDir((dir) => {
+    const f = join(dir, 'sessions.json');
+    atomicWrite(f, '{}');
+    const mode = statSync(f).mode & 0o777;
+    assert.equal(mode, 0o600);
+  });
+});
+
+test('atomicWrite: a reader never observes a partially-written file', () => {
+  // The rename is atomic, so after each write the file is either the old or new content,
+  // never a truncated mix. Simulate repeated overwrites and assert every read is complete.
+  withTmpDir((dir) => {
+    const f = join(dir, 'config.json');
+    const payloads = ['{"v":1}', '{"v":22}', '{"v":333}'];
+    for (const p of payloads) {
+      atomicWrite(f, p);
+      assert.equal(readFileSync(f, 'utf8'), p);
+    }
+  });
+});

--- a/test/http.test.ts
+++ b/test/http.test.ts
@@ -1,0 +1,207 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  fetchWithRetry,
+  isRetryableNetworkError,
+  describeNetworkError,
+} from '../src/utils/http.js';
+
+// ─── Helpers ────────────────────────────────────────────────
+
+/** Build an error shaped like a real Node/undici fetch failure: TypeError with a cause carrying the code. */
+function fetchFailure(code: string): Error {
+  return Object.assign(new TypeError('fetch failed'), { cause: { code } });
+}
+
+function okResponse(body = '{}'): Response {
+  return new Response(body, { status: 200 });
+}
+
+/** Swap out global fetch for a queue of behaviors, restoring it afterwards. */
+async function withMockFetch(
+  behaviors: Array<() => Promise<Response>>,
+  fn: (calls: { count: number }) => Promise<void>,
+): Promise<void> {
+  const original = globalThis.fetch;
+  const calls = { count: 0 };
+  globalThis.fetch = (async () => {
+    const behavior = behaviors[Math.min(calls.count, behaviors.length - 1)];
+    calls.count++;
+    return behavior();
+  }) as typeof fetch;
+  try {
+    await fn(calls);
+  } finally {
+    globalThis.fetch = original;
+  }
+}
+
+const FAST = { retryDelayMs: 1, maxRetryDelayMs: 4 } as const;
+
+// ─── isRetryableNetworkError ────────────────────────────────
+
+test('isRetryableNetworkError: classifies the issue #18 ECONNRESET as retryable', () => {
+  assert.equal(isRetryableNetworkError(fetchFailure('ECONNRESET')), true);
+});
+
+test('isRetryableNetworkError: ETIMEDOUT / EAI_AGAIN / undici socket are retryable', () => {
+  assert.equal(isRetryableNetworkError(fetchFailure('ETIMEDOUT')), true);
+  assert.equal(isRetryableNetworkError(fetchFailure('EAI_AGAIN')), true);
+  assert.equal(isRetryableNetworkError(fetchFailure('UND_ERR_SOCKET')), true);
+});
+
+test('isRetryableNetworkError: TimeoutError (AbortSignal.timeout) is retryable', () => {
+  assert.equal(isRetryableNetworkError(new DOMException('timed out', 'TimeoutError')), true);
+});
+
+test('isRetryableNetworkError: "socket hang up" message is retryable', () => {
+  assert.equal(isRetryableNetworkError(new Error('socket hang up')), true);
+});
+
+test('isRetryableNetworkError: a plain non-network error is NOT retryable', () => {
+  assert.equal(isRetryableNetworkError(new Error('bad json')), false);
+  assert.equal(isRetryableNetworkError(fetchFailure('ERR_INVALID_ARG')), false);
+});
+
+test('isRetryableNetworkError: sees the code through a DOUBLE-wrapped error (the one fetchWithRetry rethrows)', () => {
+  // fetchWithRetry rethrows `new Error(describeNetworkError(err), { cause: err })`, so the
+  // real code ends up at .cause.cause.code. A one-level lookup would miss it and the
+  // issue-#18 ECONNRESET would be mis-classified as non-retryable. (regression guard)
+  const inner = fetchFailure('ECONNRESET'); // TypeError, cause.code = ECONNRESET
+  const doubleWrapped = new Error(describeNetworkError(inner), { cause: inner });
+  assert.equal(isRetryableNetworkError(doubleWrapped), true);
+});
+
+test('describeNetworkError: still actionable on a double-wrapped error (code found, no garble)', () => {
+  const inner = fetchFailure('ECONNRESET');
+  const doubleWrapped = new Error(describeNetworkError(inner), { cause: inner });
+  const msg = describeNetworkError(doubleWrapped);
+  assert.match(msg, /ECONNRESET/);
+  assert.match(msg, /HTTPS_PROXY/);
+});
+
+// ─── describeNetworkError ───────────────────────────────────
+
+test('describeNetworkError: ECONNRESET produces an actionable Chinese hint with proxy advice', () => {
+  const msg = describeNetworkError(fetchFailure('ECONNRESET'));
+  assert.match(msg, /ECONNRESET/);
+  assert.match(msg, /HTTPS_PROXY/);
+});
+
+// ─── fetchWithRetry: the core #18 fix ───────────────────────
+
+test('fetchWithRetry: retries a transient ECONNRESET and then succeeds (issue #18)', async () => {
+  await withMockFetch(
+    [
+      () => Promise.reject(fetchFailure('ECONNRESET')),
+      () => Promise.reject(fetchFailure('ECONNRESET')),
+      () => Promise.resolve(okResponse('{"ok":true}')),
+    ],
+    async (calls) => {
+      const res = await fetchWithRetry('https://example.com', { retries: 3, ...FAST });
+      assert.equal(res.status, 200);
+      assert.equal(calls.count, 3); // failed twice, succeeded on the third attempt
+    },
+  );
+});
+
+test('fetchWithRetry: exhausts retries then throws a described (not raw) error', async () => {
+  await withMockFetch(
+    [() => Promise.reject(fetchFailure('ECONNRESET'))],
+    async (calls) => {
+      await assert.rejects(
+        () => fetchWithRetry('https://example.com', { retries: 2, ...FAST }),
+        (err: Error) => {
+          assert.match(err.message, /ECONNRESET/);
+          assert.ok((err as { cause?: unknown }).cause, 'original error preserved as cause');
+          // The rethrown error must still classify as retryable so pollLoop's diagnostic fires.
+          assert.equal(isRetryableNetworkError(err), true);
+          return true;
+        },
+      );
+      assert.equal(calls.count, 3); // 1 initial + 2 retries
+    },
+  );
+});
+
+test('fetchWithRetry: does NOT retry a non-retryable error', async () => {
+  await withMockFetch(
+    [() => Promise.reject(new Error('boom'))],
+    async (calls) => {
+      await assert.rejects(() => fetchWithRetry('https://example.com', { retries: 3, ...FAST }));
+      assert.equal(calls.count, 1); // tried exactly once
+    },
+  );
+});
+
+test('fetchWithRetry: returns 4xx without retrying (client errors are not transient)', async () => {
+  await withMockFetch(
+    [() => Promise.resolve(new Response('nope', { status: 404 }))],
+    async (calls) => {
+      const res = await fetchWithRetry('https://example.com', { retries: 3, retryOnHttpError: true, ...FAST });
+      assert.equal(res.status, 404);
+      assert.equal(calls.count, 1);
+    },
+  );
+});
+
+test('fetchWithRetry: retries 5xx only when retryOnHttpError is set', async () => {
+  // Without the flag: a single 503 is returned as-is.
+  await withMockFetch(
+    [() => Promise.resolve(new Response('busy', { status: 503 }))],
+    async (calls) => {
+      const res = await fetchWithRetry('https://example.com', { retries: 3, ...FAST });
+      assert.equal(res.status, 503);
+      assert.equal(calls.count, 1);
+    },
+  );
+  // With the flag: it retries, then succeeds.
+  await withMockFetch(
+    [
+      () => Promise.resolve(new Response('busy', { status: 503 })),
+      () => Promise.resolve(okResponse()),
+    ],
+    async (calls) => {
+      const res = await fetchWithRetry('https://example.com', { retries: 3, retryOnHttpError: true, ...FAST });
+      assert.equal(res.status, 200);
+      assert.equal(calls.count, 2);
+    },
+  );
+});
+
+test('fetchWithRetry: an already-aborted external signal throws immediately without fetching', async () => {
+  await withMockFetch(
+    [() => Promise.resolve(okResponse())],
+    async (calls) => {
+      const ac = new AbortController();
+      ac.abort();
+      await assert.rejects(
+        () => fetchWithRetry('https://example.com', { signal: ac.signal, retries: 3, ...FAST }),
+        (err: Error) => err.name === 'AbortError',
+      );
+      assert.equal(calls.count, 0); // never even attempted
+    },
+  );
+});
+
+test('fetchWithRetry: external abort mid-flight is not retried', async () => {
+  const ac = new AbortController();
+  await withMockFetch(
+    [
+      () => {
+        // Simulate the request being aborted by the caller (shutdown / cancel).
+        ac.abort();
+        return Promise.reject(Object.assign(new DOMException('Aborted', 'AbortError')));
+      },
+      () => Promise.resolve(okResponse()),
+    ],
+    async (calls) => {
+      await assert.rejects(
+        () => fetchWithRetry('https://example.com', { signal: ac.signal, retries: 3, ...FAST }),
+        (err: Error) => err.name === 'AbortError',
+      );
+      assert.equal(calls.count, 1); // aborted → no retry
+    },
+  );
+});

--- a/test/media-filename.test.ts
+++ b/test/media-filename.test.ts
@@ -1,0 +1,54 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { safeFileName } from '../src/utils/media.js';
+
+// A WeChat sender fully controls file_item.file_name and the image URL path.
+// safeFileName must guarantee the result is a bare filename that cannot escape
+// the media directory, regardless of input.
+
+test('safeFileName: strips POSIX path traversal', () => {
+  assert.equal(safeFileName('../../etc/passwd', 'file'), 'passwd');
+  assert.equal(safeFileName('/etc/shadow', 'file'), 'shadow');
+  assert.equal(safeFileName('a/b/c/report.pdf', 'file'), 'report.pdf');
+});
+
+test('safeFileName: strips Windows path traversal even on POSIX', () => {
+  assert.equal(safeFileName('..\\..\\Windows\\system32\\evil.dll', 'file'), 'evil.dll');
+  assert.equal(safeFileName('C:\\secrets\\key.txt', 'file'), 'key.txt');
+});
+
+test('safeFileName: bare ".." / "." fall back to a generated name (never traversal)', () => {
+  const a = safeFileName('..', 'file');
+  const b = safeFileName('.', 'image');
+  assert.ok(!a.includes('..'));
+  assert.match(a, /^file_/);
+  assert.match(b, /^image_/);
+});
+
+test('safeFileName: leading dots are stripped (no hidden / dotfiles like .env, .ssh)', () => {
+  assert.equal(safeFileName('.env', 'file'), 'env');
+  assert.equal(safeFileName('...config', 'file'), 'config');
+});
+
+test('safeFileName: control chars and illegal chars are neutralized', () => {
+  const out = safeFileName('a\x00b<c>d:e"f|g?h*i.txt', 'file');
+  assert.ok(!/[\x00-\x1f<>:"/\\|?*]/.test(out));
+  assert.match(out, /\.txt$/);
+});
+
+test('safeFileName: empty / undefined yields a typed generated name', () => {
+  assert.match(safeFileName(undefined, 'video'), /^video_.*\.mp4$/);
+  assert.match(safeFileName('', 'image'), /^image_.*\.jpg$/);
+});
+
+test('safeFileName: a normal name passes through unchanged', () => {
+  assert.equal(safeFileName('photo_2024.png', 'image'), 'photo_2024.png');
+  assert.equal(safeFileName('报告.pdf', 'file'), '报告.pdf');
+});
+
+test('safeFileName: overly long names are capped but keep the tail (extension)', () => {
+  const long = 'x'.repeat(500) + '.zip';
+  const out = safeFileName(long, 'file');
+  assert.ok(out.length <= 200);
+  assert.match(out, /\.zip$/);
+});

--- a/test/router.test.ts
+++ b/test/router.test.ts
@@ -251,3 +251,27 @@ test('exec maps stale default-alias model to empty before adapter execution', as
   assert.equal(capturedModels[0], '');
   assert.equal((sessions.get('u1') as any).model, '');
 });
+
+// ─── Boolean-toggle confirmations must match the stored value (regression) ───
+// Bug: update() mutates the live settings ref, so reading settings.<flag> after update()
+// reported the inverted state. These assert the reply text matches what was actually stored.
+
+for (const { cmd, field, on } of [
+  { cmd: 'verbose', field: 'verbose', on: 'ON' },
+  { cmd: 'search', field: 'search', on: 'ON' },
+  { cmd: 'ephemeral', field: 'ephemeral', on: 'ON' },
+  { cmd: 'thinking', field: 'thinking', on: 'ON (深度思考)' },
+  { cmd: 'bare', field: 'bare', on: 'ON (跳过配置加载)' },
+]) {
+  test(`/${cmd} toggle reports the value it actually stored (on then off)`, async () => {
+    const { router, sessions, messages } = createRouter();
+
+    await router.handleSlash('u1', `/${cmd}`);
+    assert.equal((sessions.get('u1') as any)[field], true, `${field} stored true`);
+    assert.ok(messages[messages.length - 1].text.includes(on), `reply says ${on}`);
+
+    await router.handleSlash('u1', `/${cmd}`);
+    assert.equal((sessions.get('u1') as any)[field], false, `${field} stored false`);
+    assert.ok(messages[messages.length - 1].text.includes('OFF'), 'reply says OFF');
+  });
+}


### PR DESCRIPTION
Fixes #18.

## 背景 / Why
启动时第一条网络请求（`getQRCode` in `src/ilink/auth.ts`）是裸 `fetch()`：**没有超时、没有重试、不读代理**。微信服务器在 TLS 握手/读取阶段偶发 `read ECONNRESET`（常见于代理/VPN、IPv6、弱网、中间设备重置），裸 fetch 直接把 `TypeError: fetch failed` 抛到 `main()`，**启动即崩**。

借这次修复，我对整个代码库做了一轮审计，顺手修了一批已验证的 bug 与改进（详见下方）。

## 核心修复 / Core fix — issue #18
- 新增 `src/utils/http.ts`：`fetchWithRetry`（每次请求超时 + 指数退避抖动重试 + 全 cause 链错误分类 + 可读中文诊断）+ 可选 `HTTPS_PROXY` 代理支持（懒加载 `undici`）。
- **所有出网调用**都改走它：扫码登录、`getupdates` 长轮询、发消息/上传/typing、媒体下载、`send` CLI。
- 长轮询保留原有截止时间（外部 `AbortSignal`），同时获得瞬时重试；轮询循环新增连续失败上限 + 抖动 + 诊断。
- 会话过期（errcode -14/-13）**自动重新扫码登录**，不再直接退出。
- 兼顾 Node 18：`AbortSignal.any` 不存在时有手写回退。
- 启动失败时打印可操作提示（代理/VPN/网络），而不是裸堆栈。

## 顺带修复（审计 + 对抗式复核）
**安全**：媒体 `file_name` 路径穿越（任意写）；Kimi 在 Windows `shell:true` 下把 prompt 当 argv → 命令注入，改走 stdin；调试日志脱敏 `aes_key`/签名 URL；数据目录权限修复；`allowedUsers` 为空时告警。
**正确性/健壮性**：`/verbose /search /ephemeral /thinking /bare` 开关确认信息**状态取反**；Codex spawn 用错 `cwd`；适配器 stdout 按 chunk `toString()` 在多字节边界**截断中文**（改 `setEncoding('utf8')`）；stdin `EPIPE` 崩溃；Windows 子进程残留（`taskkill /T`）；config/credentials/sessions **原子写**；优雅退出中止在途任务；`uncaughtException` 改为致命退出；长轮询重投消息**按用户去重**。
**测试/CI/打包**：测试命令修好（`node --import tsx`）使原本静默失败的两个 suite 真正运行，CI 现在会跑 `npm test`；**12 → 81** 个测试；`package.json` 加 `files` + `prepare` 修复发布产物缺 `dist/`。

## 测试 / Testing
`npm run typecheck`、`npm run build`、`npm test`（81 passing）均通过。覆盖重试/ECONNRESET 分类、双层包裹回归、路径穿越、开关、UTF-8 边界、原子写、脱敏、去重、Node-18 信号回退。

🤖 Generated with [Claude Code](https://claude.com/claude-code)